### PR TITLE
Split Event Tests & Fix Event Emitting & Add Error Translation Layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ dependencies = [
 [[package]]
 name = "cairo-native"
 version = "0.1.0"
-source = "git+https://github.com/NethermindEth/cairo_native?branch=powerful-errors#ff8e0cab533ffcd4403f73db2d08446d6aacf9e5"
+source = "git+https://github.com/NethermindEth/cairo_native?branch=Dom/versions#7a910873aef3d2746843f118a89328d89b8b071c"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -1071,7 +1071,7 @@ dependencies = [
 [[package]]
 name = "cairo-native-runtime"
 version = "0.1.0"
-source = "git+https://github.com/NethermindEth/cairo_native?branch=powerful-errors#ff8e0cab533ffcd4403f73db2d08446d6aacf9e5"
+source = "git+https://github.com/NethermindEth/cairo_native?branch=Dom/versions#7a910873aef3d2746843f118a89328d89b8b071c"
 dependencies = [
  "cairo-lang-runner",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ dependencies = [
 [[package]]
 name = "cairo-native"
 version = "0.1.0"
-source = "git+https://github.com/NethermindEth/cairo_native?branch=Dom/versions#6e876cb8814fa3d4ce927e4c5f534627ce5b7483"
+source = "git+https://github.com/NethermindEth/cairo_native?branch=powerful-errors#ff8e0cab533ffcd4403f73db2d08446d6aacf9e5"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -1071,7 +1071,7 @@ dependencies = [
 [[package]]
 name = "cairo-native-runtime"
 version = "0.1.0"
-source = "git+https://github.com/NethermindEth/cairo_native?branch=Dom/versions#6e876cb8814fa3d4ce927e4c5f534627ce5b7483"
+source = "git+https://github.com/NethermindEth/cairo_native?branch=powerful-errors#ff8e0cab533ffcd4403f73db2d08446d6aacf9e5"
 dependencies = [
  "cairo-lang-runner",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ cairo-lang-sierra = "2.6.0-rc.1"
 cairo-lang-starknet = "2.6.0-rc.1"
 cairo-lang-starknet-classes = "2.6.0-rc.1"
 cairo-lang-utils = "2.6.0-rc.1"
-cairo-native = { git = "https://github.com/NethermindEth/cairo_native", branch = "powerful-errors" }
+cairo-native = { git = "https://github.com/NethermindEth/cairo_native", branch = "Dom/versions" }
 cairo-vm = "0.9.2"
 criterion = "0.3"
 derive_more = "0.99.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "Apache-2.0"
 license-file = "LICENSE"
 
 [workspace.dependencies]
+
 anyhow = "1.0.0"
 ark-ec = "0.4.2"
 ark-ff = "0.4.0-alpha.7"
@@ -27,7 +28,7 @@ cairo-lang-sierra = "2.6.0-rc.1"
 cairo-lang-starknet = "2.6.0-rc.1"
 cairo-lang-starknet-classes = "2.6.0-rc.1"
 cairo-lang-utils = "2.6.0-rc.1"
-cairo-native = { git = "https://github.com/NethermindEth/cairo_native", branch = "Dom/versions" }
+cairo-native = { git = "https://github.com/NethermindEth/cairo_native", branch = "powerful-errors" }
 cairo-vm = "0.9.2"
 criterion = "0.3"
 derive_more = "0.99.17"

--- a/crates/blockifier/src/execution/errors.rs
+++ b/crates/blockifier/src/execution/errors.rs
@@ -140,8 +140,10 @@ pub enum EntryPointExecutionError {
         #[source]
         source: CairoRunError,
     },
-    #[error("Native Execution Error: {source}.")]
-    NativeExecutionError {
+    #[error("{info}")]
+    NativeExecutionError { info: String },
+    #[error("Native unexpected error: {source}")]
+    NativeUnexpectedError {
         #[source]
         source: NativeRunnerError,
     },

--- a/crates/blockifier/src/execution/execution_utils.rs
+++ b/crates/blockifier/src/execution/execution_utils.rs
@@ -35,6 +35,7 @@ use crate::state::state_api::State;
 use crate::transaction::objects::TransactionInfo;
 
 use super::contract_class::ContractClassV1;
+use super::errors::EntryPointExecutionError;
 
 pub type Args = Vec<CairoArg>;
 
@@ -87,8 +88,7 @@ pub fn execute_entry_point_call(
                 context,
             ) {
                 Ok(res) => Ok(res),
-                Err(e) if !fallback => Err(e),
-                Err(_) => {
+                Err(EntryPointExecutionError::NativeUnexpectedError { .. }) if fallback => {
                     // Fallback to VM execution in case of an Error
                     // TODO: proper error handling of this conversion from sierra class to casm
                     // class
@@ -103,6 +103,7 @@ pub fn execute_entry_point_call(
                         context,
                     )
                 }
+                Err(e) => Err(e),
             }
         }
     }

--- a/crates/blockifier/src/execution/sierra_utils.rs
+++ b/crates/blockifier/src/execution/sierra_utils.rs
@@ -250,13 +250,11 @@ pub fn create_callinfo(
 pub fn encode_str_as_felts(msg: &str) -> Vec<Felt> {
     const CHUNK_SIZE: usize = 32;
 
-    let data = msg.as_bytes();
-    let mut encoding = vec![Felt::default(); (data.len() / 32) + 1];
-    for i in 0..encoding.len() {
+    let data = msg.as_bytes().chunks(CHUNK_SIZE - 1);
+    let mut encoding = vec![Felt::default(); data.len()];
+    for (i, data_chunk) in data.enumerate() {
         let mut chunk = [0_u8; CHUNK_SIZE];
-        let a = i * CHUNK_SIZE - i;
-        let b = ((i + 1) * CHUNK_SIZE - (i + 1)).min(data.len());
-        chunk[1..CHUNK_SIZE.min(b - a + 1)].copy_from_slice(&data[a..b]);
+        chunk[1..data_chunk.len() + 1].copy_from_slice(&data_chunk);
         encoding[i] = Felt::from_bytes_be(&chunk);
     }
     encoding

--- a/crates/blockifier/src/execution/sierra_utils.rs
+++ b/crates/blockifier/src/execution/sierra_utils.rs
@@ -208,7 +208,7 @@ pub fn run_native_executor(
             info: if !res.return_values.is_empty() {
                 decode_felts_as_str(&res.return_values)
             } else {
-                String::from("unknown error")
+                String::from("Unknown error")
             },
         }),
         Err(runner_err) => {

--- a/crates/blockifier/src/execution/syscalls/syscall_tests.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests.rs
@@ -233,7 +233,6 @@ mod test_emit_event {
             data_length: max_event_data_length + 1,
             max_data_length: max_event_data_length,
         };
-
         assert!(error.to_string().contains(format!("{}", expected_error).as_str()));
     }
 
@@ -250,6 +249,7 @@ mod test_emit_event {
             keys_length: max_event_keys_length + 1,
             max_keys_length: max_event_keys_length,
         };
+
         assert!(error.to_string().contains(format!("{}", expected_error).as_str()));
     }
 

--- a/crates/blockifier/src/execution/syscalls/syscall_tests.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests.rs
@@ -191,93 +191,178 @@ fn test_call_contract(
     assert_consistent_contract_version(inner_contract, &state);
 }
 
-#[test_case(FeatureContract::SierraTestContract, NATIVE_GAS_PLACEHOLDER; "Native")]
-// fails on negative flow data length exceeding limit. Might be worth splitting this test into four, one for each case, rather than having it all in one
-#[test_case(FeatureContract::TestContract(CairoVersion::Cairo1), 82930; "VM")] // passes
-fn test_emit_event(test_contract: FeatureContract, expected_gas: u64) {
-    let versioned_constants = VersionedConstants::create_for_testing();
-    // Positive flow.
-    let keys = vec![stark_felt!(2019_u16), stark_felt!(2020_u16)];
-    let data = vec![stark_felt!(2021_u16), stark_felt!(2022_u16), stark_felt!(2023_u16)];
-    // TODO(Ori, 1/2/2024): Write an indicative expect message explaining why the conversion works.
-    let n_emitted_events = vec![stark_felt!(1_u16)];
-    let call_info = emit_events(test_contract, &n_emitted_events, &keys, &data).unwrap();
-    let event = EventContent {
-        keys: keys.clone().into_iter().map(EventKey).collect(),
-        data: EventData(data.clone()),
-    };
-    assert_eq!(
-        call_info.execution,
-        CallExecution {
-            events: vec![OrderedEvent { order: 0, event }],
-            gas_consumed: expected_gas,
-            ..Default::default()
-        }
-    );
+#[cfg(test)]
+mod test_emit_event {
+    use self::test_case;
+    use super::{assert_eq, *};
 
-    // Negative flow, the data length exceeds the limit.
-    let max_event_data_length = versioned_constants.tx_event_limits.max_data_length;
-    let data_too_long = vec![stark_felt!(2_u16); max_event_data_length + 1];
-    let error = emit_events(test_contract, &n_emitted_events, &keys, &data_too_long).unwrap_err();
-    let expected_error = EmitEventError::ExceedsMaxDataLength {
-        data_length: max_event_data_length + 1,
-        max_data_length: max_event_data_length,
-    };
-    assert!(error.to_string().contains(format!("{}", expected_error).as_str()));
+    const KEYS: [StarkFelt; 2] = [StarkFelt::from_u128(2019), StarkFelt::from_u128(2020)];
+    const DATA: [StarkFelt; 3] =
+        [StarkFelt::from_u128(2021), StarkFelt::from_u128(2022), StarkFelt::from_u128(2023)];
+    const N_EMITTED_EVENTS: [StarkFelt; 1] = [StarkFelt::from_u128(1)];
 
-    // Negative flow, the keys length exceeds the limit.
-    let max_event_keys_length = versioned_constants.tx_event_limits.max_keys_length;
-    let keys_too_long = vec![stark_felt!(1_u16); max_event_keys_length + 1];
-    let error = emit_events(test_contract, &n_emitted_events, &keys_too_long, &data).unwrap_err();
-    let expected_error = EmitEventError::ExceedsMaxKeysLength {
-        keys_length: max_event_keys_length + 1,
-        max_keys_length: max_event_keys_length,
-    };
-    assert!(error.to_string().contains(format!("{}", expected_error).as_str()));
+    #[test_case(FeatureContract::SierraTestContract, NATIVE_GAS_PLACEHOLDER; "Native")]
+    #[test_case(FeatureContract::TestContract(CairoVersion::Cairo1), 82930; "VM")]
+    fn positive_flow(test_contract: FeatureContract, expected_gas: u64) {
+        // TODO(Ori, 1/2/2024): Write an indicative expect message explaining why the conversion works.
+        let call_info = emit_events(test_contract, &N_EMITTED_EVENTS, &KEYS, &DATA).unwrap();
+        let event = EventContent {
+            keys: KEYS.clone().into_iter().map(EventKey).collect(),
+            data: EventData(DATA.to_vec()),
+        };
+        assert_eq!(
+            call_info.execution,
+            CallExecution {
+                events: vec![OrderedEvent { order: 0, event }],
+                gas_consumed: expected_gas,
+                ..Default::default()
+            }
+        );
+    }
 
-    // Negative flow, the number of events exceeds the limit.
-    let max_n_emitted_events = versioned_constants.tx_event_limits.max_n_emitted_events;
-    let n_emitted_events_too_big = vec![stark_felt!(
-        u16::try_from(max_n_emitted_events + 1).expect("Failed to convert usize to u16.")
-    )];
-    let error = emit_events(test_contract, &n_emitted_events_too_big, &keys, &data).unwrap_err();
-    let expected_error = EmitEventError::ExceedsMaxNumberOfEmittedEvents {
-        n_emitted_events: max_n_emitted_events + 1,
-        max_n_emitted_events,
-    };
-    assert!(error.to_string().contains(format!("{}", expected_error).as_str()));
+    #[test_case(FeatureContract::SierraTestContract; "Native")]
+    #[test_case(FeatureContract::TestContract(CairoVersion::Cairo1); "VM")]
+    fn data_length_exceeds_limit(test_contract: FeatureContract) {
+        let versioned_constants = VersionedConstants::create_for_testing();
+
+        let max_event_data_length = versioned_constants.tx_event_limits.max_data_length;
+        let data_too_long = vec![stark_felt!(2_u16); max_event_data_length + 1];
+        let error =
+            emit_events(test_contract, &N_EMITTED_EVENTS, &KEYS, &data_too_long).unwrap_err();
+        let expected_error = EmitEventError::ExceedsMaxDataLength {
+            data_length: max_event_data_length + 1,
+            max_data_length: max_event_data_length,
+        };
+
+        assert!(error.to_string().contains(format!("{}", expected_error).as_str()));
+    }
+
+    #[test_case(FeatureContract::SierraTestContract; "Native")]
+    #[test_case(FeatureContract::TestContract(CairoVersion::Cairo1); "VM")]
+    fn keys_length_exceeds_limit(test_contract: FeatureContract) {
+        let versioned_constants = VersionedConstants::create_for_testing();
+
+        let max_event_keys_length = versioned_constants.tx_event_limits.max_keys_length;
+        let keys_too_long = vec![stark_felt!(1_u16); max_event_keys_length + 1];
+        let error =
+            emit_events(test_contract, &N_EMITTED_EVENTS, &keys_too_long, &DATA).unwrap_err();
+        let expected_error = EmitEventError::ExceedsMaxKeysLength {
+            keys_length: max_event_keys_length + 1,
+            max_keys_length: max_event_keys_length,
+        };
+        assert!(error.to_string().contains(format!("{}", expected_error).as_str()));
+    }
+
+    #[test_case(FeatureContract::SierraTestContract; "Native")]
+    #[test_case(FeatureContract::TestContract(CairoVersion::Cairo1); "VM")]
+    fn event_number_exceeds_limit(test_contract: FeatureContract) {
+        let versioned_constants = VersionedConstants::create_for_testing();
+
+        let max_n_emitted_events = versioned_constants.tx_event_limits.max_n_emitted_events;
+        let n_emitted_events_too_big = vec![stark_felt!(
+            u16::try_from(max_n_emitted_events + 1).expect("Failed to convert usize to u16.")
+        )];
+        let error =
+            emit_events(test_contract, &n_emitted_events_too_big, &KEYS, &DATA).unwrap_err();
+        let expected_error = EmitEventError::ExceedsMaxNumberOfEmittedEvents {
+            n_emitted_events: max_n_emitted_events + 1,
+            max_n_emitted_events,
+        };
+        assert!(error.to_string().contains(format!("{}", expected_error).as_str()));
+    }
+
+    fn emit_events(
+        test_contract: FeatureContract,
+        n_emitted_events: &[StarkFelt],
+        keys: &[StarkFelt],
+        data: &[StarkFelt],
+    ) -> Result<CallInfo, EntryPointExecutionError> {
+        let chain_info = &ChainInfo::create_for_testing();
+        let mut state = test_state(chain_info, BALANCE, &[(test_contract, 1)]);
+        assert_consistent_contract_version(test_contract, &state);
+        let calldata = Calldata(
+            concat(vec![
+                n_emitted_events.to_owned(),
+                vec![stark_felt!(
+                    u16::try_from(keys.len()).expect("Failed to convert usize to u16.")
+                )],
+                keys.to_vec(),
+                vec![stark_felt!(
+                    u16::try_from(data.len()).expect("Failed to convert usize to u16.")
+                )],
+                data.to_vec(),
+            ])
+            .into(),
+        );
+
+        let entry_point_call = CallEntryPoint {
+            entry_point_selector: selector_from_name("test_emit_events"),
+            calldata,
+            ..trivial_external_entry_point_new(test_contract)
+        };
+
+        let result = entry_point_call.execute_directly(&mut state);
+        assert_consistent_contract_version(test_contract, &state);
+        result
+    }
 }
 
-fn emit_events(
-    test_contract: FeatureContract,
-    n_emitted_events: &[StarkFelt],
-    keys: &[StarkFelt],
-    data: &[StarkFelt],
-) -> Result<CallInfo, EntryPointExecutionError> {
-    let chain_info = &ChainInfo::create_for_testing();
-    let mut state = test_state(chain_info, BALANCE, &[(test_contract, 1)]);
-    assert_consistent_contract_version(test_contract, &state);
-    let calldata = Calldata(
-        concat(vec![
-            n_emitted_events.to_owned(),
-            vec![stark_felt!(u16::try_from(keys.len()).expect("Failed to convert usize to u16."))],
-            keys.to_vec(),
-            vec![stark_felt!(u16::try_from(data.len()).expect("Failed to convert usize to u16."))],
-            data.to_vec(),
-        ])
-        .into(),
-    );
-
-    let entry_point_call = CallEntryPoint {
-        entry_point_selector: selector_from_name("test_emit_events"),
-        calldata,
-        ..trivial_external_entry_point_new(test_contract)
-    };
-
-    let result = entry_point_call.execute_directly(&mut state);
-    assert_consistent_contract_version(test_contract, &state);
-    result
-}
+//#[test_case(FeatureContract::SierraTestContract, NATIVE_GAS_PLACEHOLDER; "Native")]
+//// fails on negative flow data length exceeding limit. Might be worth splitting this test into four, one for each case, rather than having it all in one
+//#[test_case(FeatureContract::TestContract(CairoVersion::Cairo1), 82930; "VM")] // passes
+//fn test_emit_event2(test_contract: FeatureContract, expected_gas: u64) {
+//    let versioned_constants = VersionedConstants::create_for_testing();
+//    // Positive flow.
+//    let keys = vec![stark_felt!(2019_u16), stark_felt!(2020_u16)];
+//    let data = vec![stark_felt!(2021_u16), stark_felt!(2022_u16), stark_felt!(2023_u16)];
+//    // TODO(Ori, 1/2/2024): Write an indicative expect message explaining why the conversion works.
+//    let n_emitted_events = vec![stark_felt!(1_u16)];
+//    let call_info = emit_events(test_contract, &n_emitted_events, &keys, &data).unwrap();
+//    let event = EventContent {
+//        keys: keys.clone().into_iter().map(EventKey).collect(),
+//        data: EventData(data.clone()),
+//    };
+//    assert_eq!(
+//        call_info.execution,
+//        CallExecution {
+//            events: vec![OrderedEvent { order: 0, event }],
+//            gas_consumed: expected_gas,
+//            ..Default::default()
+//        }
+//    );
+//
+//    // Negative flow, the data length exceeds the limit.
+//    let max_event_data_length = versioned_constants.tx_event_limits.max_data_length;
+//    let data_too_long = vec![stark_felt!(2_u16); max_event_data_length + 1];
+//    let error = emit_events(test_contract, &n_emitted_events, &keys, &data_too_long).unwrap_err();
+//    let expected_error = EmitEventError::ExceedsMaxDataLength {
+//        data_length: max_event_data_length + 1,
+//        max_data_length: max_event_data_length,
+//    };
+//    assert!(error.to_string().contains(format!("{}", expected_error).as_str()));
+//
+//    // Negative flow, the keys length exceeds the limit.
+//    let max_event_keys_length = versioned_constants.tx_event_limits.max_keys_length;
+//    let keys_too_long = vec![stark_felt!(1_u16); max_event_keys_length + 1];
+//    let error = emit_events(test_contract, &n_emitted_events, &keys_too_long, &data).unwrap_err();
+//    let expected_error = EmitEventError::ExceedsMaxKeysLength {
+//        keys_length: max_event_keys_length + 1,
+//        max_keys_length: max_event_keys_length,
+//    };
+//    assert!(error.to_string().contains(format!("{}", expected_error).as_str()));
+//
+//    // Negative flow, the number of events exceeds the limit.
+//    let max_n_emitted_events = versioned_constants.tx_event_limits.max_n_emitted_events;
+//    let n_emitted_events_too_big = vec![stark_felt!(
+//        u16::try_from(max_n_emitted_events + 1).expect("Failed to convert usize to u16.")
+//    )];
+//    let error = emit_events(test_contract, &n_emitted_events_too_big, &keys, &data).unwrap_err();
+//    let expected_error = EmitEventError::ExceedsMaxNumberOfEmittedEvents {
+//        n_emitted_events: max_n_emitted_events + 1,
+//        max_n_emitted_events,
+//    };
+//    assert!(error.to_string().contains(format!("{}", expected_error).as_str()));
+//}
 
 #[test_case(FeatureContract::SierraTestContract, NATIVE_GAS_PLACEHOLDER; "Native")] // pass
 #[test_case(FeatureContract::TestContract(CairoVersion::Cairo1), 14250; "VM")] // unauthorised syscall get_block_hash in execution mode Validate

--- a/crates/blockifier/src/execution/syscalls/syscall_tests.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests.rs
@@ -268,7 +268,7 @@ mod test_emit_event {
             n_emitted_events: max_n_emitted_events + 1,
             max_n_emitted_events,
         };
-        assert!(error.to_string().contains(format!("{}", expected_error).as_str()));
+        assert!(error.to_string().contains(&expected_error.to_string()));
     }
 
     fn emit_events(

--- a/crates/blockifier/src/execution/syscalls/syscall_tests.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests.rs
@@ -233,7 +233,7 @@ mod test_emit_event {
             data_length: max_event_data_length + 1,
             max_data_length: max_event_data_length,
         };
-        assert!(error.to_string().contains(format!("{}", expected_error).as_str()));
+        assert!(error.to_string().contains(&expected_error.to_string()));
     }
 
     #[test_case(FeatureContract::SierraTestContract; "Native")]
@@ -250,7 +250,7 @@ mod test_emit_event {
             max_keys_length: max_event_keys_length,
         };
 
-        assert!(error.to_string().contains(format!("{}", expected_error).as_str()));
+        assert!(error.to_string().contains(&expected_error.to_string()));
     }
 
     #[test_case(FeatureContract::SierraTestContract; "Native")]

--- a/crates/blockifier/src/execution/syscalls/syscall_tests.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests.rs
@@ -307,63 +307,6 @@ mod test_emit_event {
     }
 }
 
-//#[test_case(FeatureContract::SierraTestContract, NATIVE_GAS_PLACEHOLDER; "Native")]
-//// fails on negative flow data length exceeding limit. Might be worth splitting this test into four, one for each case, rather than having it all in one
-//#[test_case(FeatureContract::TestContract(CairoVersion::Cairo1), 82930; "VM")] // passes
-//fn test_emit_event2(test_contract: FeatureContract, expected_gas: u64) {
-//    let versioned_constants = VersionedConstants::create_for_testing();
-//    // Positive flow.
-//    let keys = vec![stark_felt!(2019_u16), stark_felt!(2020_u16)];
-//    let data = vec![stark_felt!(2021_u16), stark_felt!(2022_u16), stark_felt!(2023_u16)];
-//    // TODO(Ori, 1/2/2024): Write an indicative expect message explaining why the conversion works.
-//    let n_emitted_events = vec![stark_felt!(1_u16)];
-//    let call_info = emit_events(test_contract, &n_emitted_events, &keys, &data).unwrap();
-//    let event = EventContent {
-//        keys: keys.clone().into_iter().map(EventKey).collect(),
-//        data: EventData(data.clone()),
-//    };
-//    assert_eq!(
-//        call_info.execution,
-//        CallExecution {
-//            events: vec![OrderedEvent { order: 0, event }],
-//            gas_consumed: expected_gas,
-//            ..Default::default()
-//        }
-//    );
-//
-//    // Negative flow, the data length exceeds the limit.
-//    let max_event_data_length = versioned_constants.tx_event_limits.max_data_length;
-//    let data_too_long = vec![stark_felt!(2_u16); max_event_data_length + 1];
-//    let error = emit_events(test_contract, &n_emitted_events, &keys, &data_too_long).unwrap_err();
-//    let expected_error = EmitEventError::ExceedsMaxDataLength {
-//        data_length: max_event_data_length + 1,
-//        max_data_length: max_event_data_length,
-//    };
-//    assert!(error.to_string().contains(format!("{}", expected_error).as_str()));
-//
-//    // Negative flow, the keys length exceeds the limit.
-//    let max_event_keys_length = versioned_constants.tx_event_limits.max_keys_length;
-//    let keys_too_long = vec![stark_felt!(1_u16); max_event_keys_length + 1];
-//    let error = emit_events(test_contract, &n_emitted_events, &keys_too_long, &data).unwrap_err();
-//    let expected_error = EmitEventError::ExceedsMaxKeysLength {
-//        keys_length: max_event_keys_length + 1,
-//        max_keys_length: max_event_keys_length,
-//    };
-//    assert!(error.to_string().contains(format!("{}", expected_error).as_str()));
-//
-//    // Negative flow, the number of events exceeds the limit.
-//    let max_n_emitted_events = versioned_constants.tx_event_limits.max_n_emitted_events;
-//    let n_emitted_events_too_big = vec![stark_felt!(
-//        u16::try_from(max_n_emitted_events + 1).expect("Failed to convert usize to u16.")
-//    )];
-//    let error = emit_events(test_contract, &n_emitted_events_too_big, &keys, &data).unwrap_err();
-//    let expected_error = EmitEventError::ExceedsMaxNumberOfEmittedEvents {
-//        n_emitted_events: max_n_emitted_events + 1,
-//        max_n_emitted_events,
-//    };
-//    assert!(error.to_string().contains(format!("{}", expected_error).as_str()));
-//}
-
 #[test_case(FeatureContract::SierraTestContract, NATIVE_GAS_PLACEHOLDER; "Native")] // pass
 #[test_case(FeatureContract::TestContract(CairoVersion::Cairo1), 14250; "VM")] // unauthorised syscall get_block_hash in execution mode Validate
 fn test_get_block_hash(test_contract: FeatureContract, expected_gas: u64) {


### PR DESCRIPTION
1. Events tests where all together inside one, so they got split.
2. Syscall `event_emit` wasn't performing cartain checks (data size, key size, & number of event emitted)
3. Unified the way Native errors were given to be more in line to what is currently existing.

Fix #33
Fix #34 