### PR TITLE
Track inner calls & Storage changes

### DIFF
--- a/crates/blockifier/src/execution/native_entry_point_execution.rs
+++ b/crates/blockifier/src/execution/native_entry_point_execution.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use cairo_lang_sierra::program::Program as SierraProgram;
 use cairo_lang_starknet_classes::contract_class::ContractEntryPoints;
 use starknet_api::core::ClassHash;
@@ -45,6 +47,8 @@ pub fn execute_entry_point_call(
         Vec::new(),
         Vec::new(),
         Vec::new(),
+        Vec::new(),
+        HashSet::new(),
     );
 
     let syscall_handler_meta = wrap_syscall_handler(&mut syscall_handler);
@@ -65,5 +69,7 @@ pub fn execute_entry_point_call(
         syscall_handler.events,
         syscall_handler.l2_to_l1_messages,
         syscall_handler.inner_calls,
+        syscall_handler.storage_read_values,
+        syscall_handler.accessed_storage_keys,
     )
 }

--- a/crates/blockifier/src/execution/native_syscall_handler.rs
+++ b/crates/blockifier/src/execution/native_syscall_handler.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+use std::hash::RandomState;
 use std::sync::Arc;
 
 use cairo_native::starknet::{
@@ -31,9 +33,8 @@ use crate::execution::entry_point::{
 };
 use crate::execution::execution_utils::execute_deployment;
 use crate::execution::syscalls::hint_processor::{
-    execute_inner_call_raw, BLOCK_NUMBER_OUT_OF_RANGE_ERROR, FAILED_TO_CALCULATE_CONTRACT_ADDRESS,
-    FAILED_TO_EXECUTE_CALL, FAILED_TO_READ_RESULT, FAILED_TO_WRITE, INVALID_ARGUMENT,
-    INVALID_EXECUTION_MODE_ERROR, INVALID_INPUT_LENGTH_ERROR,
+    BLOCK_NUMBER_OUT_OF_RANGE_ERROR, FAILED_TO_CALCULATE_CONTRACT_ADDRESS, FAILED_TO_EXECUTE_CALL,
+    INVALID_ARGUMENT, INVALID_EXECUTION_MODE_ERROR, INVALID_INPUT_LENGTH_ERROR,
 };
 use crate::state::state_api::State;
 
@@ -47,6 +48,8 @@ pub struct NativeSyscallHandler<'state> {
     pub events: Vec<OrderedEvent>,
     pub l2_to_l1_messages: Vec<OrderedL2ToL1Message>,
     pub inner_calls: Vec<CallInfo>,
+    pub storage_read_values: Vec<StarkFelt>,
+    pub accessed_storage_keys: HashSet<StorageKey, RandomState>,
 }
 
 impl<'state> StarkNetSyscallHandler for NativeSyscallHandler<'state> {
@@ -268,12 +271,21 @@ impl<'state> StarkNetSyscallHandler for NativeSyscallHandler<'state> {
             initial_gas: *remaining_gas as u64,
         };
 
-        execute_inner_call_raw(
-            entry_point,
-            self.state,
-            &mut self.execution_resources,
-            &mut self.execution_context,
-        )
+        let call_info = entry_point
+            .execute(self.state, &mut self.execution_resources, &mut self.execution_context)
+            .map_err(|e| encode_str_as_felts(&e.to_string()))?;
+
+        let retdata = call_info
+            .execution
+            .retdata
+            .0
+            .iter()
+            .map(|felt| starkfelt_to_felt(*felt))
+            .collect::<Vec<Felt>>();
+
+        self.inner_calls.push(call_info);
+
+        Ok(retdata)
     }
 
     fn call_contract(
@@ -310,12 +322,21 @@ impl<'state> StarkNetSyscallHandler for NativeSyscallHandler<'state> {
             initial_gas: *remaining_gas as u64,
         };
 
-        execute_inner_call_raw(
-            entry_point,
-            self.state,
-            &mut self.execution_resources,
-            &mut self.execution_context,
-        )
+        let call_info = entry_point
+            .execute(self.state, &mut self.execution_resources, &mut self.execution_context)
+            .map_err(|e| encode_str_as_felts(&e.to_string()))?;
+
+        let retdata = call_info
+            .execution
+            .retdata
+            .0
+            .iter()
+            .map(|felt| starkfelt_to_felt(*felt))
+            .collect::<Vec<Felt>>();
+
+        self.inner_calls.push(call_info);
+
+        Ok(retdata)
     }
 
     fn storage_read(
@@ -324,14 +345,12 @@ impl<'state> StarkNetSyscallHandler for NativeSyscallHandler<'state> {
         address: Felt,
         _remaining_gas: &mut u128,
     ) -> SyscallResult<Felt> {
-        // TODO - in progress - Dom
         let storage_key = StorageKey(
             PatriciaKey::try_from(felt_to_starkfelt(address))
-                .map_err(|_| vec![Felt::from_hex(INVALID_ARGUMENT).unwrap()])?,
+                .map_err(|e| encode_str_as_felts(&e.to_string()))?,
         );
         let read_result = self.state.get_storage_at(self.contract_address, storage_key);
-        let unsafe_read_result =
-            read_result.map_err(|_| vec![Felt::from_hex(FAILED_TO_READ_RESULT).unwrap()])?;
+        let unsafe_read_result = read_result.map_err(|e| encode_str_as_felts(&e.to_string()))?;
 
         Ok(starkfelt_to_felt(unsafe_read_result))
     }
@@ -350,7 +369,7 @@ impl<'state> StarkNetSyscallHandler for NativeSyscallHandler<'state> {
 
         let write_result =
             self.state.set_storage_at(self.contract_address, storage_key, felt_to_starkfelt(value));
-        write_result.map_err(|_| vec![Felt::from_hex(FAILED_TO_WRITE).unwrap()])?;
+        write_result.map_err(|e| encode_str_as_felts(&e.to_string()))?;
         Ok(())
     }
 

--- a/crates/blockifier/src/execution/sierra_utils.rs
+++ b/crates/blockifier/src/execution/sierra_utils.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
+use std::hash::RandomState;
 use std::rc::Rc;
 
 use cairo_lang_sierra::ids::FunctionId;
@@ -17,6 +18,7 @@ use num_traits::ToBytes;
 use starknet_api::core::{ChainId, ClassHash, ContractAddress, EntryPointSelector};
 use starknet_api::deprecated_contract_class::EntryPointType;
 use starknet_api::hash::StarkFelt;
+use starknet_api::state::StorageKey;
 use starknet_types_core::felt::{Felt, FromStrError};
 
 use super::call_info::{CallExecution, CallInfo, OrderedEvent, OrderedL2ToL1Message, Retdata};
@@ -224,6 +226,8 @@ pub fn create_callinfo(
     events: Vec<OrderedEvent>,
     l2_to_l1_messages: Vec<OrderedL2ToL1Message>,
     inner_calls: Vec<CallInfo>,
+    storage_read_values: Vec<StarkFelt>,
+    accessed_storage_keys: HashSet<StorageKey, RandomState>,
 ) -> Result<CallInfo, super::errors::EntryPointExecutionError> {
     Ok(CallInfo {
         call,
@@ -240,10 +244,10 @@ pub fn create_callinfo(
             n_steps: 0,
             n_memory_holes: 0,
             builtin_instance_counter: HashMap::default(),
-        }, // REVIEW what do we do with this, given that we can't count casm steps
+        },
         inner_calls,
-        storage_read_values: vec![],
-        accessed_storage_keys: HashSet::new(),
+        storage_read_values,
+        accessed_storage_keys,
     })
 }
 

--- a/crates/blockifier/src/execution/sierra_utils.rs
+++ b/crates/blockifier/src/execution/sierra_utils.rs
@@ -135,6 +135,8 @@ pub fn setup_syscall_handler<'state>(
     events: Vec<OrderedEvent>,
     l2_to_l1_messages: Vec<OrderedL2ToL1Message>,
     inner_calls: Vec<CallInfo>,
+    storage_read_values: Vec<StarkFelt>,
+    accessed_storage_keys: HashSet<StorageKey, RandomState>,
 ) -> NativeSyscallHandler<'state> {
     NativeSyscallHandler {
         state,
@@ -146,6 +148,8 @@ pub fn setup_syscall_handler<'state>(
         l2_to_l1_messages,
         execution_resources,
         inner_calls,
+        storage_read_values,
+        accessed_storage_keys,
     }
 }
 

--- a/crates/blockifier/src/execution/syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/syscalls/hint_processor.rs
@@ -22,7 +22,6 @@ use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
 use starknet_api::transaction::{Calldata, Resource};
 use starknet_api::StarknetApiError;
-use starknet_types_core::felt::Felt;
 use thiserror::Error;
 
 use crate::abi::sierra_types::SierraTypeError;
@@ -34,7 +33,6 @@ use crate::execution::execution_utils::{
     felt_range_from_ptr, max_fee_for_execution_info, stark_felt_from_ptr, stark_felt_to_felt,
     write_maybe_relocatable, ReadOnlySegment, ReadOnlySegments,
 };
-use crate::execution::sierra_utils::{encode_str_as_felts, starkfelt_to_felt};
 use crate::execution::syscalls::secp::{
     secp256k1_add, secp256k1_get_point_from_x, secp256k1_get_xy, secp256k1_mul, secp256k1_new,
     secp256r1_add, secp256r1_get_point_from_x, secp256r1_get_xy, secp256r1_mul, secp256r1_new,
@@ -170,14 +168,11 @@ pub const FAILED_TO_CALCULATE_CONTRACT_ADDRESS: &str =
     "0x004661696c656420746f2063616c63756c6174652061646472657373";
 // Failed to parse
 pub const FAILED_TO_PARSE: &str = "0x004661696c656420746f20706172736520";
-// Failed to read result
-pub const FAILED_TO_READ_RESULT: &str = "0x004661696c656420746f207265616420726573756c7420";
-// Failed to write
-pub const FAILED_TO_WRITE: &str = "0x004661696c656420746f20777269746520";
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use starknet_types_core::felt::Felt;
 
     #[test]
     fn test_felt_from_hex() {
@@ -191,7 +186,6 @@ mod tests {
         assert!(Felt::from_hex(FAILED_TO_EXECUTE_CALL).is_ok());
         assert!(Felt::from_hex(FAILED_TO_CALCULATE_CONTRACT_ADDRESS).is_ok());
         assert!(Felt::from_hex(FAILED_TO_PARSE).is_ok());
-        assert!(Felt::from_hex(FAILED_TO_READ_RESULT).is_ok());
     }
 }
 
@@ -772,28 +766,6 @@ pub fn execute_inner_call(
     syscall_handler.inner_calls.push(call_info);
 
     Ok(retdata_segment)
-}
-
-pub fn execute_inner_call_raw(
-    call: CallEntryPoint,
-    state: &mut dyn State,
-    execution_resources: &mut ExecutionResources,
-    context: &mut EntryPointExecutionContext,
-) -> cairo_native::starknet::SyscallResult<Vec<Felt>> {
-    // todo: remove execution resources?
-    let call_info = call
-        .execute(state, execution_resources, context)
-        .map_err(|e| encode_str_as_felts(&e.to_string()))?;
-
-    let retdata = call_info
-        .execution
-        .retdata
-        .0
-        .into_iter()
-        .map(|felt| starkfelt_to_felt(felt))
-        .collect::<Vec<Felt>>();
-
-    Ok(retdata)
 }
 
 pub fn create_retdata_segment(


### PR DESCRIPTION
This PR fixes the storage, library and contract call syscalls. 

It also modifies the nested_library_calls to "ignore" the invalid execution resources metering used by Native.