### PR TITLE
fix: zero caller address being propagated

### DIFF
--- a/crates/blockifier/src/execution/native/syscall_handler.rs
+++ b/crates/blockifier/src/execution/native/syscall_handler.rs
@@ -451,7 +451,7 @@ impl<'state> StarknetSyscallHandler for &mut NativeSyscallHandler<'state> {
             ))),
             calldata: wrapper_calldata,
             storage_address: contract_address,
-            caller_address: self.caller_address,
+            caller_address: self.contract_address,
             call_type: CallType::Call,
             initial_gas: u64::try_from(*remaining_gas).unwrap(),
         };

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/get_execution_info.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/get_execution_info.rs
@@ -34,57 +34,94 @@ use crate::transaction::objects::{
     CommonAccountFields, CurrentTransactionInfo, DeprecatedTransactionInfo, TransactionInfo,
 };
 
+
+// TODO even more thorough testing with native
+#[test_case(
+    FeatureContract::SierraTestContract,
+    ExecutionMode::Validate,
+    TransactionVersion::ONE,
+    false,
+    false;
+    "Native: Validate execution mode: block info fields should be zeroed. Transaction V1.")]
+#[test_case(
+    FeatureContract::SierraTestContract,
+    ExecutionMode::Execute,
+    TransactionVersion::ONE,
+    false,
+    false;
+    "Native: Execute execution mode: block info should be as usual. Transaction V1.")]
+#[test_case(
+    FeatureContract::SierraTestContract,
+    ExecutionMode::Validate,
+    TransactionVersion::THREE,
+    false,
+    false;
+    "Native: Validate execution mode: block info fields should be zeroed. Transaction V3.")]
+#[test_case(
+    FeatureContract::SierraTestContract,
+    ExecutionMode::Execute,
+    TransactionVersion::THREE,
+    false,
+    false;
+    "Native: Execute execution mode: block info should be as usual. Transaction V3.")]
 // TODO Native
 #[test_case(
+    FeatureContract::TestContract(CairoVersion::Cairo1),
     ExecutionMode::Validate,
     TransactionVersion::ONE,
     false,
     false;
     "Validate execution mode: block info fields should be zeroed. Transaction V1.")]
 #[test_case(
+    FeatureContract::TestContract(CairoVersion::Cairo1),
     ExecutionMode::Execute,
     TransactionVersion::ONE,
     false,
     false;
     "Execute execution mode: block info should be as usual. Transaction V1.")]
 #[test_case(
+    FeatureContract::TestContract(CairoVersion::Cairo1),
     ExecutionMode::Validate,
     TransactionVersion::THREE,
     false,
     false;
     "Validate execution mode: block info fields should be zeroed. Transaction V3.")]
 #[test_case(
+    FeatureContract::TestContract(CairoVersion::Cairo1),
     ExecutionMode::Execute,
     TransactionVersion::THREE,
     false,
     false;
     "Execute execution mode: block info should be as usual. Transaction V3.")]
 #[test_case(
+    FeatureContract::TestContract(CairoVersion::Cairo1),
     ExecutionMode::Execute,
     TransactionVersion::ONE,
     true,
     false;
     "Legacy contract. Execute execution mode: block info should be as usual. Transaction V1.")]
 #[test_case(
+    FeatureContract::TestContract(CairoVersion::Cairo1),
     ExecutionMode::Execute,
     TransactionVersion::THREE,
     true,
     false;
     "Legacy contract. Execute execution mode: block info should be as usual. Transaction V3.")]
 #[test_case(
+    FeatureContract::TestContract(CairoVersion::Cairo1),
     ExecutionMode::Execute,
     TransactionVersion::THREE,
     false,
     true;
     "Execute execution mode: block info should be as usual. Transaction V3. Query.")]
 fn test_get_execution_info(
+    test_contract: FeatureContract,
     execution_mode: ExecutionMode,
     mut version: TransactionVersion,
     is_legacy: bool,
     only_query: bool,
 ) {
     let legacy_contract = FeatureContract::LegacyTestContract;
-    let test_contract = FeatureContract::TestContract(CairoVersion::Cairo1);
     let state = &mut test_state(
         &ChainInfo::create_for_testing(),
         BALANCE,

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/get_execution_info.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/get_execution_info.rs
@@ -34,7 +34,6 @@ use crate::transaction::objects::{
     CommonAccountFields, CurrentTransactionInfo, DeprecatedTransactionInfo, TransactionInfo,
 };
 
-
 // TODO even more thorough testing with native
 #[test_case(
     FeatureContract::SierraTestContract,


### PR DESCRIPTION
Previously we were passing the current caller address as the caller address for the call generated from call_contract. Instead, we should be passing the current address as it is the one calling the target contract. A little extra testing is added here for get_execution_info (which is used for getting the caller address), though more should be added in time