### PR TITLE
fix: use of wrong hint processor

### DIFF
--- a/crates/blockifier/src/execution/syscalls/secp.rs
+++ b/crates/blockifier/src/execution/syscalls/secp.rs
@@ -113,7 +113,7 @@ where
         Ok(SecpNewResponse { optional_ec_point_id: Some(self.allocate_point(ec_point)) })
     }
 
-    fn allocate_point(&mut self, ec_point: short_weierstrass::Affine<Curve>) -> usize {
+    pub fn allocate_point(&mut self, ec_point: short_weierstrass::Affine<Curve>) -> usize {
         let points = &mut self.points;
         let id = points.len();
         points.push(ec_point);


### PR DESCRIPTION
To prevent mixing hint processors the secp_256 operations have been made methods to the hint processor. That way there will never be two hint processors in scope at the same time.