### PR TITLE
fix: overallocation of points when using secp256 operations on native

### DIFF
--- a/crates/blockifier/src/execution/native/syscall_handler.rs
+++ b/crates/blockifier/src/execution/native/syscall_handler.rs
@@ -25,7 +25,7 @@ use starknet_api::transaction::{
 use starknet_types_core::felt::Felt;
 
 use super::utils::{
-    allocate_point, big4int_to_u256, calculate_resource_bounds, contract_address_to_native_felt,
+    big4int_to_u256, calculate_resource_bounds, contract_address_to_native_felt,
     default_tx_v2_info, encode_str_as_felts, native_felt_to_stark_felt, stark_felt_to_native_felt,
     u256_to_biguint,
 };
@@ -42,8 +42,8 @@ use crate::execution::syscalls::hint_processor::{
     SyscallExecutionError, BLOCK_NUMBER_OUT_OF_RANGE_ERROR, INVALID_INPUT_LENGTH_ERROR,
 };
 use crate::execution::syscalls::secp::{
-    SecpGetPointFromXRequest, SecpGetPointFromXResponse, SecpHintProcessor, SecpMulRequest,
-    SecpMulResponse, SecpNewRequest, SecpNewResponse,
+    SecpGetPointFromXRequest, SecpGetPointFromXResponse, SecpHintProcessor, SecpNewRequest,
+    SecpNewResponse,
 };
 use crate::state::state_api::State;
 use crate::transaction::objects::TransactionInfo;
@@ -715,25 +715,18 @@ where
         p0: Secp256Point<Curve>,
         p1: Secp256Point<Curve>,
     ) -> Result<Secp256Point<Curve>, Vec<Felt>> {
-        let lhs = Affine::<Curve>::new(u256_to_biguint(p0.x).into(), u256_to_biguint(p0.y).into());
-        let rhs = Affine::<Curve>::new(u256_to_biguint(p1.x).into(), u256_to_biguint(p1.y).into());
+        let lhs: Affine<Curve> = p0.into();
+        let rhs: Affine<Curve> = p1.into();
         let result = lhs + rhs;
         let ec_point_id = self.allocate_point(result.into());
         self.get_secp256point_by_id(ec_point_id)
     }
 
     fn mul(&mut self, p: Secp256Point<Curve>, m: U256) -> Result<Secp256Point<Curve>, Vec<Felt>> {
-        let p_id = allocate_point(p.x, p.y, self)?;
-        let request =
-            SecpMulRequest { ec_point_id: Felt252::from(p_id), multiplier: u256_to_biguint(m) };
-
-        match self.secp_mul(request) {
-            Ok(SecpMulResponse { ec_point_id: id }) => self.get_secp256point_by_id(id),
-            Err(SyscallExecutionError::SyscallError { error_data }) => {
-                Err(error_data.iter().map(|felt| stark_felt_to_native_felt(*felt)).collect())
-            }
-            Err(error) => Err(encode_str_as_felts(&error.to_string())),
-        }
+        let p: Affine<Curve> = p.into();
+        let result = p * Curve::ScalarField::from(u256_to_biguint(m));
+        let ec_point_id = self.allocate_point(result.into());
+        self.get_secp256point_by_id(ec_point_id)
     }
 
     fn get_point_from_x(
@@ -818,5 +811,14 @@ impl From<Secp256k1Point> for Secp256Point<ark_secp256k1::Config> {
 impl From<Secp256r1Point> for Secp256Point<ark_secp256r1::Config> {
     fn from(p: Secp256r1Point) -> Self {
         Secp256Point::new(p.x, p.y)
+    }
+}
+
+impl<Curve: SWCurveConfig> From<Secp256Point<Curve>> for Affine<Curve>
+where
+    Curve::BaseField: From<num_bigint::BigUint>,
+{
+    fn from(p: Secp256Point<Curve>) -> Self {
+        Affine::<Curve>::new(u256_to_biguint(p.x).into(), u256_to_biguint(p.y).into())
     }
 }

--- a/crates/blockifier/src/execution/syscalls/secp.rs
+++ b/crates/blockifier/src/execution/syscalls/secp.rs
@@ -53,7 +53,7 @@ where
         if request.x >= modulos {
             return Err(SyscallExecutionError::SyscallError {
                 error_data: vec![
-                    StarkFelt::try_from(INVALID_ARGUMENT).map_err(SyscallExecutionError::from)?,
+                    StarkFelt::try_from(INVALID_ARGUMENT).map_err(SyscallExecutionError::from)?
                 ],
             });
         }
@@ -62,7 +62,11 @@ where
         let maybe_ec_point = short_weierstrass::Affine::<Curve>::get_ys_from_x_unchecked(x)
             .map(|(smaller, greater)| {
                 // Return the correct y coordinate based on the parity.
-                if smaller.into_bigint().is_odd() == request.y_parity { smaller } else { greater }
+                if smaller.into_bigint().is_odd() == request.y_parity {
+                    smaller
+                } else {
+                    greater
+                }
             })
             .map(|y| short_weierstrass::Affine::<Curve>::new_unchecked(x, y))
             .filter(|p| p.is_in_correct_subgroup_assuming_on_curve());
@@ -101,7 +105,7 @@ where
         if x >= modulos || y >= modulos {
             return Err(SyscallExecutionError::SyscallError {
                 error_data: vec![
-                    StarkFelt::try_from(INVALID_ARGUMENT).map_err(SyscallExecutionError::from)?,
+                    StarkFelt::try_from(INVALID_ARGUMENT).map_err(SyscallExecutionError::from)?
                 ],
             });
         }
@@ -113,7 +117,8 @@ where
         Ok(SecpNewResponse { optional_ec_point_id: Some(self.allocate_point(ec_point)) })
     }
 
-    fn allocate_point(&mut self, ec_point: short_weierstrass::Affine<Curve>) -> usize {
+    // see if you can undo making this public
+    pub fn allocate_point(&mut self, ec_point: short_weierstrass::Affine<Curve>) -> usize {
         let points = &mut self.points;
         let id = points.len();
         points.push(ec_point);

--- a/crates/blockifier/src/execution/syscalls/secp.rs
+++ b/crates/blockifier/src/execution/syscalls/secp.rs
@@ -53,7 +53,7 @@ where
         if request.x >= modulos {
             return Err(SyscallExecutionError::SyscallError {
                 error_data: vec![
-                    StarkFelt::try_from(INVALID_ARGUMENT).map_err(SyscallExecutionError::from)?
+                    StarkFelt::try_from(INVALID_ARGUMENT).map_err(SyscallExecutionError::from)?,
                 ],
             });
         }
@@ -62,11 +62,7 @@ where
         let maybe_ec_point = short_weierstrass::Affine::<Curve>::get_ys_from_x_unchecked(x)
             .map(|(smaller, greater)| {
                 // Return the correct y coordinate based on the parity.
-                if smaller.into_bigint().is_odd() == request.y_parity {
-                    smaller
-                } else {
-                    greater
-                }
+                if smaller.into_bigint().is_odd() == request.y_parity { smaller } else { greater }
             })
             .map(|y| short_weierstrass::Affine::<Curve>::new_unchecked(x, y))
             .filter(|p| p.is_in_correct_subgroup_assuming_on_curve());
@@ -105,7 +101,7 @@ where
         if x >= modulos || y >= modulos {
             return Err(SyscallExecutionError::SyscallError {
                 error_data: vec![
-                    StarkFelt::try_from(INVALID_ARGUMENT).map_err(SyscallExecutionError::from)?
+                    StarkFelt::try_from(INVALID_ARGUMENT).map_err(SyscallExecutionError::from)?,
                 ],
             });
         }
@@ -117,7 +113,6 @@ where
         Ok(SecpNewResponse { optional_ec_point_id: Some(self.allocate_point(ec_point)) })
     }
 
-    // see if you can undo making this public
     pub fn allocate_point(&mut self, ec_point: short_weierstrass::Affine<Curve>) -> usize {
         let points = &mut self.points;
         let id = points.len();


### PR DESCRIPTION
fix #95

Whenever an secp256 addition or multiplication is performed the arguments were unnecessarily allocated.
