### PR TITLE
refactor: test_get_execution_info

### DIFF
--- a/crates/blockifier/src/execution/syscalls/syscall_tests/get_execution_info.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/get_execution_info.rs
@@ -222,8 +222,8 @@ fn test_get_execution_info(
                 resource_bounds: ResourceBoundsMapping(BTreeMap::from([
                     (
                         Resource::L1Gas,
-                        // TODO(Ori, 1/2/2024): Write an indicative expect message explaining why the
-                        // convertion works.
+                        // TODO(Ori, 1/2/2024): Write an indicative expect message explaining why
+                        // the convertion works.
                         ResourceBounds {
                             max_amount: max_amount
                                 .0

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/get_execution_info.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/get_execution_info.rs
@@ -39,28 +39,24 @@ use crate::transaction::objects::{
     FeatureContract::SierraTestContract,
     ExecutionMode::Validate,
     TransactionVersion::ONE,
-    false,
     false;
     "Native: Validate execution mode: block info fields should be zeroed. Transaction V1.")]
 #[test_case(
     FeatureContract::SierraTestContract,
     ExecutionMode::Execute,
     TransactionVersion::ONE,
-    false,
     false;
     "Native: Execute execution mode: block info should be as usual. Transaction V1.")]
 #[test_case(
     FeatureContract::SierraTestContract,
     ExecutionMode::Validate,
     TransactionVersion::THREE,
-    false,
     false;
     "Native: Validate execution mode: block info fields should be zeroed. Transaction V3.")]
 #[test_case(
     FeatureContract::SierraTestContract,
     ExecutionMode::Execute,
     TransactionVersion::THREE,
-    false,
     false;
     "Native: Execute execution mode: block info should be as usual. Transaction V3.")]
 // TODO Native
@@ -68,58 +64,51 @@ use crate::transaction::objects::{
     FeatureContract::TestContract(CairoVersion::Cairo1),
     ExecutionMode::Validate,
     TransactionVersion::ONE,
-    false,
     false;
     "Validate execution mode: block info fields should be zeroed. Transaction V1.")]
 #[test_case(
     FeatureContract::TestContract(CairoVersion::Cairo1),
     ExecutionMode::Execute,
     TransactionVersion::ONE,
-    false,
     false;
     "Execute execution mode: block info should be as usual. Transaction V1.")]
 #[test_case(
     FeatureContract::TestContract(CairoVersion::Cairo1),
     ExecutionMode::Validate,
     TransactionVersion::THREE,
-    false,
     false;
     "Validate execution mode: block info fields should be zeroed. Transaction V3.")]
 #[test_case(
     FeatureContract::TestContract(CairoVersion::Cairo1),
     ExecutionMode::Execute,
     TransactionVersion::THREE,
-    false,
     false;
     "Execute execution mode: block info should be as usual. Transaction V3.")]
 #[test_case(
-    FeatureContract::TestContract(CairoVersion::Cairo1),
+    FeatureContract::LegacyTestContract,
     ExecutionMode::Execute,
     TransactionVersion::ONE,
-    true,
     false;
     "Legacy contract. Execute execution mode: block info should be as usual. Transaction V1.")]
 #[test_case(
-    FeatureContract::TestContract(CairoVersion::Cairo1),
+    FeatureContract::LegacyTestContract,
     ExecutionMode::Execute,
     TransactionVersion::THREE,
-    true,
     false;
     "Legacy contract. Execute execution mode: block info should be as usual. Transaction V3.")]
 #[test_case(
     FeatureContract::TestContract(CairoVersion::Cairo1),
     ExecutionMode::Execute,
     TransactionVersion::THREE,
-    false,
     true;
     "Execute execution mode: block info should be as usual. Transaction V3. Query.")]
 fn test_get_execution_info(
     test_contract: FeatureContract,
     execution_mode: ExecutionMode,
     mut version: TransactionVersion,
-    is_legacy: bool,
     only_query: bool,
 ) {
+    let is_legacy = test_contract == FeatureContract::LegacyTestContract;
     let legacy_contract = FeatureContract::LegacyTestContract;
     let state = &mut test_state(
         &ChainInfo::create_for_testing(),
@@ -173,85 +162,88 @@ fn test_get_execution_info(
     let expected_tx_info: Vec<StarkFelt>;
     let mut expected_resource_bounds: Vec<StarkFelt> = vec![];
     let tx_info: TransactionInfo;
-    if version == TransactionVersion::ONE {
-        expected_tx_info = vec![
-            version.0,                                                  // Transaction version.
-            *sender_address.0.key(),                                    // Account address.
-            stark_felt!(max_fee.0),                                     // Max fee.
-            StarkFelt::ZERO,                                            // Signature.
-            tx_hash.0,                                                  // Transaction hash.
-            stark_felt!(&*ChainId(CHAIN_ID_NAME.to_string()).as_hex()), // Chain ID.
-            nonce.0,                                                    // Nonce.
-        ];
-        if !is_legacy {
-            expected_resource_bounds = vec![
-                stark_felt!(0_u16), // Length of resource bounds array.
+    match version {
+        TransactionVersion::ONE => {
+            expected_tx_info = vec![
+                version.0,                                                  // Transaction version.
+                *sender_address.0.key(),                                    // Account address.
+                stark_felt!(max_fee.0),                                     // Max fee.
+                StarkFelt::ZERO,                                            // Signature.
+                tx_hash.0,                                                  // Transaction hash.
+                stark_felt!(&*ChainId(CHAIN_ID_NAME.to_string()).as_hex()), // Chain ID.
+                nonce.0,                                                    // Nonce.
             ];
+            if !is_legacy {
+                expected_resource_bounds = vec![
+                    stark_felt!(0_u16), // Length of resource bounds array.
+                ];
+            }
+            tx_info = TransactionInfo::Deprecated(DeprecatedTransactionInfo {
+                common_fields: CommonAccountFields {
+                    transaction_hash: tx_hash,
+                    version: TransactionVersion::ONE,
+                    nonce,
+                    sender_address,
+                    only_query,
+                    ..Default::default()
+                },
+                max_fee,
+            });
         }
-        tx_info = TransactionInfo::Deprecated(DeprecatedTransactionInfo {
-            common_fields: CommonAccountFields {
-                transaction_hash: tx_hash,
-                version: TransactionVersion::ONE,
-                nonce,
-                sender_address,
-                only_query,
-                ..Default::default()
-            },
-            max_fee,
-        });
-    } else {
-        let max_amount = Fee(13);
-        let max_price_per_unit = Fee(61);
-        expected_tx_info = vec![
-            version.0,                                                  // Transaction version.
-            *sender_address.0.key(),                                    // Account address.
-            StarkFelt::ZERO,                                            // Max fee.
-            StarkFelt::ZERO,                                            // Signature.
-            tx_hash.0,                                                  // Transaction hash.
-            stark_felt!(&*ChainId(CHAIN_ID_NAME.to_string()).as_hex()), // Chain ID.
-            nonce.0,                                                    // Nonce.
-        ];
-        if !is_legacy {
-            expected_resource_bounds = vec![
-                StarkFelt::from(2u32),             // Length of ResourceBounds array.
-                stark_felt!(L1_GAS),               // Resource.
-                stark_felt!(max_amount.0),         // Max amount.
-                stark_felt!(max_price_per_unit.0), // Max price per unit.
-                stark_felt!(L2_GAS),               // Resource.
-                StarkFelt::ZERO,                   // Max amount.
-                StarkFelt::ZERO,                   // Max price per unit.
+        _ => {
+            let max_amount = Fee(13);
+            let max_price_per_unit = Fee(61);
+            expected_tx_info = vec![
+                version.0,                                                  // Transaction version.
+                *sender_address.0.key(),                                    // Account address.
+                StarkFelt::ZERO,                                            // Max fee.
+                StarkFelt::ZERO,                                            // Signature.
+                tx_hash.0,                                                  // Transaction hash.
+                stark_felt!(&*ChainId(CHAIN_ID_NAME.to_string()).as_hex()), // Chain ID.
+                nonce.0,                                                    // Nonce.
             ];
+            if !is_legacy {
+                expected_resource_bounds = vec![
+                    StarkFelt::from(2u32),             // Length of ResourceBounds array.
+                    stark_felt!(L1_GAS),               // Resource.
+                    stark_felt!(max_amount.0),         // Max amount.
+                    stark_felt!(max_price_per_unit.0), // Max price per unit.
+                    stark_felt!(L2_GAS),               // Resource.
+                    StarkFelt::ZERO,                   // Max amount.
+                    StarkFelt::ZERO,                   // Max price per unit.
+                ];
+            }
+            tx_info = TransactionInfo::Current(CurrentTransactionInfo {
+                common_fields: CommonAccountFields {
+                    transaction_hash: tx_hash,
+                    version: TransactionVersion::THREE,
+                    nonce,
+                    sender_address,
+                    only_query,
+                    ..Default::default()
+                },
+                resource_bounds: ResourceBoundsMapping(BTreeMap::from([
+                    (
+                        Resource::L1Gas,
+                        // TODO(Ori, 1/2/2024): Write an indicative expect message explaining why the
+                        // convertion works.
+                        ResourceBounds {
+                            max_amount: max_amount
+                                .0
+                                .try_into()
+                                .expect("Failed to convert u128 to u64."),
+                            max_price_per_unit: max_price_per_unit.0,
+                        },
+                    ),
+                    (Resource::L2Gas, ResourceBounds { max_amount: 0, max_price_per_unit: 0 }),
+                ])),
+                tip: Tip::default(),
+                nonce_data_availability_mode: DataAvailabilityMode::L1,
+                fee_data_availability_mode: DataAvailabilityMode::L1,
+                paymaster_data: PaymasterData::default(),
+                account_deployment_data: AccountDeploymentData::default(),
+            });
         }
-        tx_info = TransactionInfo::Current(CurrentTransactionInfo {
-            common_fields: CommonAccountFields {
-                transaction_hash: tx_hash,
-                version: TransactionVersion::THREE,
-                nonce,
-                sender_address,
-                only_query,
-                ..Default::default()
-            },
-            resource_bounds: ResourceBoundsMapping(BTreeMap::from([
-                (
-                    Resource::L1Gas,
-                    // TODO(Ori, 1/2/2024): Write an indicative expect message explaining why the
-                    // convertion works.
-                    ResourceBounds {
-                        max_amount: max_amount
-                            .0
-                            .try_into()
-                            .expect("Failed to convert u128 to u64."),
-                        max_price_per_unit: max_price_per_unit.0,
-                    },
-                ),
-                (Resource::L2Gas, ResourceBounds { max_amount: 0, max_price_per_unit: 0 }),
-            ])),
-            tip: Tip::default(),
-            nonce_data_availability_mode: DataAvailabilityMode::L1,
-            fee_data_availability_mode: DataAvailabilityMode::L1,
-            paymaster_data: PaymasterData::default(),
-            account_deployment_data: AccountDeploymentData::default(),
-        });
     }
 
     let entry_point_selector = selector_from_name("test_get_execution_info");


### PR DESCRIPTION
Closes #98

By using pattern matching instead of `if-else` branches we can drop the argument `is_legacy`, turn a mutable variable into a immutable one, and make the decision table behind `expected_resource_bounds` apparent. 


