### PR TITLE
fix: remove U256 workarounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,7 +1014,7 @@ dependencies = [
 [[package]]
 name = "cairo-native"
 version = "0.2.0"
-source = "git+https://github.com/lambdaclass/cairo_native?rev=9527cc9d17b4708b5fb969133f4af924636cee02#9527cc9d17b4708b5fb969133f4af924636cee02"
+source = "git+https://github.com/lambdaclass/cairo_native?rev=dc6f129c9e943923443345f2ea40842e463d50a8#dc6f129c9e943923443345f2ea40842e463d50a8"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -1064,7 +1064,7 @@ dependencies = [
 [[package]]
 name = "cairo-native-runtime"
 version = "0.2.0"
-source = "git+https://github.com/lambdaclass/cairo_native?rev=9527cc9d17b4708b5fb969133f4af924636cee02#9527cc9d17b4708b5fb969133f4af924636cee02"
+source = "git+https://github.com/lambdaclass/cairo_native?rev=dc6f129c9e943923443345f2ea40842e463d50a8#dc6f129c9e943923443345f2ea40842e463d50a8"
 dependencies = [
  "cairo-lang-runner",
  "cairo-lang-sierra-gas",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,7 +1014,7 @@ dependencies = [
 [[package]]
 name = "cairo-native"
 version = "0.2.0"
-source = "git+https://github.com/lambdaclass/cairo_native?rev=66e9b5e#66e9b5e053faf3b2a9129de5b15205d1cfe686eb"
+source = "git+https://github.com/lambdaclass/cairo_native?rev=9527cc9d17b4708b5fb969133f4af924636cee02#9527cc9d17b4708b5fb969133f4af924636cee02"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -1064,7 +1064,7 @@ dependencies = [
 [[package]]
 name = "cairo-native-runtime"
 version = "0.2.0"
-source = "git+https://github.com/lambdaclass/cairo_native?rev=66e9b5e#66e9b5e053faf3b2a9129de5b15205d1cfe686eb"
+source = "git+https://github.com/lambdaclass/cairo_native?rev=9527cc9d17b4708b5fb969133f4af924636cee02#9527cc9d17b4708b5fb969133f4af924636cee02"
 dependencies = [
  "cairo-lang-runner",
  "cairo-lang-sierra-gas",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ cairo-lang-sierra = "=2.6.4"
 cairo-lang-starknet = "=2.6.4"
 cairo-lang-starknet-classes = "=2.6.4"
 cairo-lang-utils = "=2.6.4"
-cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "66e9b5e" } # main
+cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "9527cc9d17b4708b5fb969133f4af924636cee02" } # main
 cairo-vm = "0.9.2"
 criterion = "0.3"
 derive_more = "0.99.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ cairo-lang-sierra = "=2.6.4"
 cairo-lang-starknet = "=2.6.4"
 cairo-lang-starknet-classes = "=2.6.4"
 cairo-lang-utils = "=2.6.4"
-cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "9527cc9d17b4708b5fb969133f4af924636cee02" } # main
+cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "dc6f129c9e943923443345f2ea40842e463d50a8" } # main
 cairo-vm = "0.9.2"
 criterion = "0.3"
 derive_more = "0.99.17"

--- a/crates/blockifier/src/execution/native/syscall_handler.rs
+++ b/crates/blockifier/src/execution/native/syscall_handler.rs
@@ -820,19 +820,11 @@ where
     ark_ff::BigInt<4>: From<<Curve>::BaseField>,
 {
     fn from(point: Affine<Curve>) -> Self {
-        // A workaround for turning big4int into a u256 that matches the way the
-        // result of native and VM are displayed.
-        // Having to swap around is most-likely a bug, but best investigated after
-        // https://github.com/NethermindEth/blockifier/issues/97
-        fn swap(x: U256) -> U256 {
-            U256 { hi: x.lo, lo: x.hi }
-        }
-
         // Here /into/ must be used, accessing the BigInt via .0 will lead to an
         // transformation being missed.
         let x = big4int_to_u256(point.x.into());
         let y = big4int_to_u256(point.y.into());
 
-        Self { x: swap(x), y: swap(y), _phantom: Default::default() }
+        Self { x, y, _phantom: Default::default() }
     }
 }

--- a/crates/blockifier/src/execution/native/syscall_handler.rs
+++ b/crates/blockifier/src/execution/native/syscall_handler.rs
@@ -577,8 +577,8 @@ impl<'state> StarknetSyscallHandler for &mut NativeSyscallHandler<'state> {
         }
 
         Ok(U256 {
-            lo: u128::from(state[2]) | (u128::from(state[3]) << 64),
-            hi: u128::from(state[0]) | (u128::from(state[1]) << 64),
+            hi: u128::from(state[2]) | (u128::from(state[3]) << 64),
+            lo: u128::from(state[0]) | (u128::from(state[1]) << 64),
         })
     }
 

--- a/crates/blockifier/src/execution/native/utils.rs
+++ b/crates/blockifier/src/execution/native/utils.rs
@@ -227,7 +227,7 @@ pub fn u256_to_biguint(u256: U256) -> BigUint {
     let lo = BigUint::from(u256.lo);
     let hi = BigUint::from(u256.hi);
 
-    hi + (lo << 128) // 128 is the size of lo
+    (hi << 128) + lo
 }
 
 pub fn big4int_to_u256(b_int: BigInt<4>) -> U256 {

--- a/crates/blockifier/src/execution/native/utils_test.rs
+++ b/crates/blockifier/src/execution/native/utils_test.rs
@@ -20,7 +20,7 @@ fn test_u256_to_biguint() {
     let u256 = U256 { lo: 0x1234_5678, hi: 0x9abc_def0 };
 
     let expected_biguint =
-        BigUint::from_str_radix("123456780000000000000000000000009abcdef0", 16).unwrap();
+        BigUint::from_str_radix("9abcdef000000000000000000000000012345678", 16).unwrap();
 
     let actual_biguint = u256_to_biguint(u256);
 


### PR DESCRIPTION
Fix: https://github.com/NethermindEth/blockifier/issues/97

Cairo native has fixed the byte order of U256 and in this PR we incorporate the fix and remove our workaround. 