### PR TITLE
fix: borrow checking for program cache

### DIFF
--- a/crates/blockifier/src/execution/entry_point.rs
+++ b/crates/blockifier/src/execution/entry_point.rs
@@ -101,31 +101,12 @@ impl CallEntryPoint {
         self.class_hash = Some(class_hash);
         let contract_class = state.get_compiled_contract_class(class_hash)?;
 
-        match program_cache {
-            Some(program_cache) => execute_entry_point_call(
-                self,
-                contract_class,
-                state,
-                resources,
-                context,
-                program_cache,
-            ),
-            None => {
-                // If no cache was provided, create a temporary one to last for the duration of this
-                // execution
-                let program_cache = get_native_aot_program_cache();
-                let program_cache = &mut (*program_cache.borrow_mut());
+        let mut empty_program_cache = get_native_aot_program_cache();
 
-                execute_entry_point_call(
-                    self,
-                    contract_class,
-                    state,
-                    resources,
-                    context,
-                    program_cache,
-                )
-            }
-        }
+        let program_cache =
+            program_cache.unwrap_or(std::borrow::BorrowMut::borrow_mut(&mut empty_program_cache));
+
+        execute_entry_point_call(self, contract_class, state, resources, context, program_cache)
     }
 }
 

--- a/crates/blockifier/src/execution/native/utils.rs
+++ b/crates/blockifier/src/execution/native/utils.rs
@@ -1,7 +1,5 @@
-use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::hash::RandomState;
-use std::rc::Rc;
 
 use ark_ff::BigInt;
 use cairo_lang_sierra::ids::FunctionId;
@@ -74,16 +72,12 @@ pub fn match_entrypoint(
 static NATIVE_CONTEXT: std::sync::OnceLock<cairo_native::context::NativeContext> =
     std::sync::OnceLock::new();
 
-pub fn get_native_aot_program_cache<'context>() -> Rc<RefCell<ProgramCache<'context, ClassHash>>> {
-    Rc::new(RefCell::new(ProgramCache::Aot(AotProgramCache::new(
-        NATIVE_CONTEXT.get_or_init(NativeContext::new),
-    ))))
+pub fn get_native_aot_program_cache<'context>() -> ProgramCache<'context, ClassHash> {
+    ProgramCache::Aot(AotProgramCache::new(NATIVE_CONTEXT.get_or_init(NativeContext::new)))
 }
 
-pub fn get_native_jit_program_cache<'context>() -> Rc<RefCell<ProgramCache<'context, ClassHash>>> {
-    Rc::new(RefCell::new(ProgramCache::Jit(JitProgramCache::new(
-        NATIVE_CONTEXT.get_or_init(NativeContext::new),
-    ))))
+pub fn get_native_jit_program_cache<'context>() -> ProgramCache<'context, ClassHash> {
+    ProgramCache::Jit(JitProgramCache::new(NATIVE_CONTEXT.get_or_init(NativeContext::new)))
 }
 
 pub fn get_native_executor<'context>(

--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -643,11 +643,7 @@ impl AccountTransaction {
     /// Returns 0 on non-declare transactions; for declare transactions, returns the class code
     /// size.
     pub(crate) fn declare_code_size(&self) -> usize {
-        if let Self::Declare(tx) = self {
-            tx.class_info.code_size()
-        } else {
-            0
-        }
+        if let Self::Declare(tx) = self { tx.class_info.code_size() } else { 0 }
     }
 
     fn is_non_revertible(&self, tx_info: &TransactionInfo) -> bool {


### PR DESCRIPTION
With the introduction of `program_cache` quite some code was unnecessarily duplicated to get around the borrow checker. This PR does properly deal with the borrow checker for `program_cache`. 