### PR TITLE
feat: use cached state instead of separate program_cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist
 target
 */.vscode/*
 *.DS_Store
+.envrc
 
 tmp_venv/*
 

--- a/crates/blockifier/bench/blockifier_bench.rs
+++ b/crates/blockifier/bench/blockifier_bench.rs
@@ -105,7 +105,7 @@ fn do_transfer(
     let account_tx = AccountTransaction::Invoke(tx);
     let charge_fee = CHARGE_FEE;
     let validate = RUN_VALIDATION;
-    account_tx.execute(state, block_context, charge_fee, validate, None).unwrap();
+    account_tx.execute(state, block_context, charge_fee, validate).unwrap();
 }
 
 criterion_group!(benches, transfers_benchmark);

--- a/crates/blockifier/src/blockifier/stateful_validator_test.rs
+++ b/crates/blockifier/src/blockifier/stateful_validator_test.rs
@@ -72,6 +72,6 @@ fn test_transaction_validator(
         BouncerConfig::create_for_testing(),
     );
 
-    let reuslt = stateful_validator.perform_validations(tx, None, None);
+    let reuslt = stateful_validator.perform_validations(tx, None);
     assert!(reuslt.is_ok(), "Validation failed: {:?}", reuslt.unwrap_err());
 }

--- a/crates/blockifier/src/blockifier/transaction_executor.rs
+++ b/crates/blockifier/src/blockifier/transaction_executor.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use cairo_native::cache::ProgramCache;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use itertools::FoldWhile::{Continue, Done};
 use itertools::Itertools;
@@ -73,18 +72,12 @@ impl<S: StateReader> TransactionExecutor<S> {
         &mut self,
         tx: &Transaction,
         charge_fee: bool,
-        program_cache: Option<&mut ProgramCache<'_, ClassHash>>,
     ) -> TransactionExecutorResult<TransactionExecutionInfo> {
         let mut transactional_state = CachedState::create_transactional(&mut self.state);
         let validate = true;
 
-        let tx_execution_result = tx.execute_raw(
-            &mut transactional_state,
-            &self.block_context,
-            charge_fee,
-            validate,
-            program_cache,
-        );
+        let tx_execution_result =
+            tx.execute_raw(&mut transactional_state, &self.block_context, charge_fee, validate);
         match tx_execution_result {
             Ok(tx_execution_info) => {
                 self.bouncer.try_update(
@@ -109,10 +102,9 @@ impl<S: StateReader> TransactionExecutor<S> {
         &mut self,
         txs: &[Transaction],
         charge_fee: bool,
-        program_cache: Option<&mut ProgramCache<'_, ClassHash>>,
     ) -> Vec<TransactionExecutorResult<TransactionExecutionInfo>> {
         if !self.config.concurrency_config.enabled {
-            self.execute_txs_sequentially(txs, charge_fee, program_cache)
+            self.execute_txs_sequentially(txs, charge_fee)
         } else {
             txs.chunks(self.config.concurrency_config.chunk_size)
                 .fold_while(Vec::new(), |mut results, chunk| {
@@ -142,14 +134,9 @@ impl<S: StateReader> TransactionExecutor<S> {
         &mut self,
         txs: &[Transaction],
         charge_fee: bool,
-        program_cache: Option<&mut ProgramCache<'_, ClassHash>>,
     ) -> Vec<TransactionExecutorResult<TransactionExecutionInfo>> {
         let mut results_to_return = Vec::new();
-        let results = if let Some(cache) = program_cache {
-            txs.iter().map(|tx| self.execute(tx, charge_fee, Some(cache))).collect_vec()
-        } else {
-            txs.iter().map(|tx| self.execute(tx, charge_fee, None)).collect_vec()
-        };
+        let results = txs.iter().map(|tx| self.execute(tx, charge_fee)).collect_vec();
 
         for result in results {
             match result {
@@ -166,7 +153,6 @@ impl<S: StateReader> TransactionExecutor<S> {
         &mut self,
         account_tx: &AccountTransaction,
         mut remaining_gas: u64,
-        program_cache: Option<&mut ProgramCache<'_, ClassHash>>,
     ) -> TransactionExecutorResult<(Option<CallInfo>, TransactionReceipt)> {
         let mut execution_resources = ExecutionResources::default();
         let tx_context = Arc::new(self.block_context.to_tx_context(account_tx));
@@ -186,7 +172,6 @@ impl<S: StateReader> TransactionExecutor<S> {
             tx_context.clone(),
             &mut remaining_gas,
             limit_steps_by_resources,
-            program_cache,
         )?;
 
         let tx_receipt = TransactionReceipt::from_account_tx(

--- a/crates/blockifier/src/blockifier/transaction_executor_test.rs
+++ b/crates/blockifier/src/blockifier/transaction_executor_test.rs
@@ -44,7 +44,7 @@ fn tx_executor_test_body<S: StateReader>(
     // TODO(Arni, 30/03/2024): Consider adding a test for the transaction execution info. If A test
     // should not be added, rename the test to `test_bouncer_info`.
     // TODO(Arni, 30/03/2024): Test all bouncer weights.
-    let _tx_execution_info = tx_executor.execute(&tx, charge_fee, None).unwrap();
+    let _tx_execution_info = tx_executor.execute(&tx, charge_fee).unwrap();
     let bouncer_weights = tx_executor.bouncer.get_accumulated_weights();
     assert_eq!(bouncer_weights.state_diff_size, expected_bouncer_weights.state_diff_size);
     assert_eq!(
@@ -276,7 +276,6 @@ fn test_bouncing(
                 nonce_manager.next(account_address),
             )),
             true,
-            None,
         )
         .map_err(|error| panic!("{error:?}: {error}"))
         .unwrap();
@@ -322,7 +321,7 @@ fn test_execute_txs_bouncing(block_context: BlockContext) {
     .collect();
 
     // Run.
-    let results = tx_executor.execute_txs(&txs, true, None);
+    let results = tx_executor.execute_txs(&txs, true);
 
     // Check execution results.
     let expected_offset = 3;
@@ -342,12 +341,12 @@ fn test_execute_txs_bouncing(block_context: BlockContext) {
 
     // Check idempotency: excess transactions should not be added.
     let remaining_txs = &txs[expected_offset..];
-    let remaining_tx_results = tx_executor.execute_txs(remaining_txs, true, None);
+    let remaining_tx_results = tx_executor.execute_txs(remaining_txs, true);
     assert_eq!(remaining_tx_results.len(), 0);
 
     // Reset the bouncer and add the remaining transactions.
     tx_executor.bouncer = Bouncer::new(bouncer_config);
-    let remaining_tx_results = tx_executor.execute_txs(remaining_txs, true, None);
+    let remaining_tx_results = tx_executor.execute_txs(remaining_txs, true);
 
     assert_eq!(remaining_tx_results.len(), 2);
     assert!(remaining_tx_results[0].is_ok());

--- a/crates/blockifier/src/concurrency/versioned_state_proxy_test.rs
+++ b/crates/blockifier/src/concurrency/versioned_state_proxy_test.rs
@@ -244,12 +244,12 @@ fn test_run_parallel_txs() {
     let block_context_2 = block_context.clone();
     // Execute transactions
     let thread_handle_1 = thread::spawn(move || {
-        let result = account_tx_1.execute(&mut state_1, &block_context_1, true, true, None);
+        let result = account_tx_1.execute(&mut state_1, &block_context_1, true, true);
         assert_eq!(result.is_err(), enforce_fee);
     });
 
     let thread_handle_2 = thread::spawn(move || {
-        account_tx_2.execute(&mut state_2, &block_context_2, true, true, None).unwrap();
+        account_tx_2.execute(&mut state_2, &block_context_2, true, true).unwrap();
 
         // Check that the constructor wrote ctor_arg to the storage.
         let storage_key = get_storage_var_address("ctor_arg", &[]);
@@ -301,11 +301,9 @@ fn test_validate_read_set(
     // TODO(OriF 15/5/24): add a check for `get_compiled_contract_class`` once the deploy account
     // preceding a declare flow is solved.
 
-    assert!(
-        safe_versioned_state
-            .pin_version(1)
-            .validate_read_set(&transactional_state.cache.borrow().initial_reads)
-    );
+    assert!(safe_versioned_state
+        .pin_version(1)
+        .validate_read_set(&transactional_state.cache.borrow().initial_reads));
 }
 
 #[rstest]

--- a/crates/blockifier/src/concurrency/versioned_state_proxy_test.rs
+++ b/crates/blockifier/src/concurrency/versioned_state_proxy_test.rs
@@ -301,9 +301,11 @@ fn test_validate_read_set(
     // TODO(OriF 15/5/24): add a check for `get_compiled_contract_class`` once the deploy account
     // preceding a declare flow is solved.
 
-    assert!(safe_versioned_state
-        .pin_version(1)
-        .validate_read_set(&transactional_state.cache.borrow().initial_reads));
+    assert!(
+        safe_versioned_state
+            .pin_version(1)
+            .validate_read_set(&transactional_state.cache.borrow().initial_reads)
+    );
 }
 
 #[rstest]

--- a/crates/blockifier/src/execution/contract_address_test.rs
+++ b/crates/blockifier/src/execution/contract_address_test.rs
@@ -43,7 +43,7 @@ fn test_calculate_contract_address() {
                 .unwrap();
 
         assert_eq!(
-            entry_point_call.execute_directly(state, None).unwrap().execution,
+            entry_point_call.execute_directly(state).unwrap().execution,
             CallExecution::from_retdata(retdata![*contract_address.0.key()])
         );
     }

--- a/crates/blockifier/src/execution/contract_class.rs
+++ b/crates/blockifier/src/execution/contract_class.rs
@@ -132,7 +132,7 @@ impl ContractClassV0 {
             + self.n_builtins()
             + self.bytecode_length()
             + 1; // Hinted class hash.
-        // The hashed data size is approximately the number of hashes (invoked in hash chains).
+                 // The hashed data size is approximately the number of hashes (invoked in hash chains).
         let n_steps = constants::N_STEPS_PER_PEDERSEN * hashed_data_size;
 
         ExecutionResources {
@@ -597,8 +597,6 @@ pub struct SierraContractClassV1Inner {
     pub sierra_program: SierraProgram,
     pub entry_points_by_type: SierraContractEntryPoints,
     sierra_program_raw: Vec<BigUintAsHex>,
-    // Throughout the code base ContractClasses are cloned a lot
-    // therefore we put the NativeExecutor in an Arc.
     pub executor: AotNativeExecutor,
 }
 

--- a/crates/blockifier/src/execution/contract_class.rs
+++ b/crates/blockifier/src/execution/contract_class.rs
@@ -549,10 +549,10 @@ impl SierraContractClassV1 {
     }
 
     pub fn try_from_json_string(raw_contract_class: &str) -> Result<Self, ProgramError> {
-        fn compile(sierra_program: &SierraProgram) -> Arc<AotNativeExecutor> {
+        fn compile(sierra_program: &SierraProgram) -> AotNativeExecutor {
             let native_context = cairo_native::context::NativeContext::new();
             let native_program = native_context.compile(sierra_program, None).unwrap();
-            Arc::new(AotNativeExecutor::from_native_module(native_program, OptLevel::Default))
+            AotNativeExecutor::from_native_module(native_program, OptLevel::Default)
         }
 
         let sierra_contract_class: SierraContractClass = serde_json::from_str(raw_contract_class)?;
@@ -588,7 +588,7 @@ impl SierraContractClassV1 {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct SierraContractClassV1Inner {
     // todo(xrvdg) can we make sierra_program private such that it
     // is only available for debugging purposes?
@@ -599,7 +599,7 @@ pub struct SierraContractClassV1Inner {
     sierra_program_raw: Vec<BigUintAsHex>,
     // Throughout the code base ContractClasses are cloned a lot
     // therefore we put the NativeExecutor in an Arc.
-    pub executor: Arc<AotNativeExecutor>,
+    pub executor: AotNativeExecutor,
 }
 
 // Manual implementation as the executor has no comparison

--- a/crates/blockifier/src/execution/contract_class.rs
+++ b/crates/blockifier/src/execution/contract_class.rs
@@ -134,7 +134,7 @@ impl ContractClassV0 {
             + self.n_builtins()
             + self.bytecode_length()
             + 1; // Hinted class hash.
-                 // The hashed data size is approximately the number of hashes (invoked in hash chains).
+        // The hashed data size is approximately the number of hashes (invoked in hash chains).
         let n_steps = constants::N_STEPS_PER_PEDERSEN * hashed_data_size;
 
         ExecutionResources {

--- a/crates/blockifier/src/execution/contract_class.rs
+++ b/crates/blockifier/src/execution/contract_class.rs
@@ -132,7 +132,7 @@ impl ContractClassV0 {
             + self.n_builtins()
             + self.bytecode_length()
             + 1; // Hinted class hash.
-                 // The hashed data size is approximately the number of hashes (invoked in hash chains).
+        // The hashed data size is approximately the number of hashes (invoked in hash chains).
         let n_steps = constants::N_STEPS_PER_PEDERSEN * hashed_data_size;
 
         ExecutionResources {

--- a/crates/blockifier/src/execution/deprecated_entry_point_execution.rs
+++ b/crates/blockifier/src/execution/deprecated_entry_point_execution.rs
@@ -1,9 +1,8 @@
-use cairo_native::cache::ProgramCache;
 use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
 use cairo_vm::vm::errors::vm_errors::VirtualMachineError;
 use cairo_vm::vm::runners::cairo_runner::{CairoArg, CairoRunner, ExecutionResources};
 use cairo_vm::vm::vm_core::VirtualMachine;
-use starknet_api::core::{ClassHash, EntryPointSelector};
+use starknet_api::core::EntryPointSelector;
 use starknet_api::deprecated_contract_class::EntryPointType;
 use starknet_api::hash::StarkHash;
 
@@ -21,10 +20,10 @@ use crate::execution::execution_utils::{
 };
 use crate::state::state_api::State;
 
-pub struct VmExecutionContext<'a, 'context> {
+pub struct VmExecutionContext<'a> {
     pub runner: CairoRunner,
     pub vm: VirtualMachine,
-    pub syscall_handler: DeprecatedSyscallHintProcessor<'a, 'context>,
+    pub syscall_handler: DeprecatedSyscallHintProcessor<'a>,
     pub initial_syscall_ptr: Relocatable,
     pub entry_point_pc: usize,
 }
@@ -36,7 +35,6 @@ pub fn execute_entry_point_call(
     state: &mut dyn State,
     resources: &mut ExecutionResources,
     context: &mut EntryPointExecutionContext,
-    cache: &mut ProgramCache<'_, ClassHash>,
 ) -> EntryPointExecutionResult<CallInfo> {
     let VmExecutionContext {
         mut runner,
@@ -44,7 +42,7 @@ pub fn execute_entry_point_call(
         mut syscall_handler,
         initial_syscall_ptr,
         entry_point_pc,
-    } = initialize_execution_context(&call, contract_class, state, resources, context, cache)?;
+    } = initialize_execution_context(&call, contract_class, state, resources, context)?;
 
     let (implicit_args, args) = prepare_call_arguments(
         &call,
@@ -71,14 +69,13 @@ pub fn execute_entry_point_call(
     )?)
 }
 
-pub fn initialize_execution_context<'a, 'context>(
+pub fn initialize_execution_context<'a>(
     call: &CallEntryPoint,
     contract_class: ContractClassV0,
     state: &'a mut dyn State,
     resources: &'a mut ExecutionResources,
     context: &'a mut EntryPointExecutionContext,
-    cache: &'a mut ProgramCache<'context, ClassHash>,
-) -> Result<VmExecutionContext<'a, 'context>, PreExecutionError> {
+) -> Result<VmExecutionContext<'a>, PreExecutionError> {
     // Resolve initial PC from EP indicator.
     let entry_point_pc = resolve_entry_point_pc(call, &contract_class)?;
 
@@ -101,7 +98,6 @@ pub fn initialize_execution_context<'a, 'context>(
         initial_syscall_ptr,
         call.storage_address,
         call.caller_address,
-        cache,
     );
 
     Ok(VmExecutionContext { runner, vm, syscall_handler, initial_syscall_ptr, entry_point_pc })
@@ -192,7 +188,7 @@ pub fn prepare_call_arguments(
 pub fn run_entry_point(
     vm: &mut VirtualMachine,
     runner: &mut CairoRunner,
-    hint_processor: &mut DeprecatedSyscallHintProcessor<'_, '_>,
+    hint_processor: &mut DeprecatedSyscallHintProcessor<'_>,
     entry_point_pc: usize,
     args: Args,
 ) -> EntryPointExecutionResult<()> {
@@ -214,7 +210,7 @@ pub fn run_entry_point(
 pub fn finalize_execution(
     mut vm: VirtualMachine,
     runner: CairoRunner,
-    syscall_handler: DeprecatedSyscallHintProcessor<'_, '_>,
+    syscall_handler: DeprecatedSyscallHintProcessor<'_>,
     call: CallEntryPoint,
     previous_resources: ExecutionResources,
     implicit_args: Vec<MaybeRelocatable>,
@@ -267,7 +263,7 @@ pub fn finalize_execution(
 pub fn validate_run(
     vm: &mut VirtualMachine,
     runner: &CairoRunner,
-    syscall_handler: &DeprecatedSyscallHintProcessor<'_, '_>,
+    syscall_handler: &DeprecatedSyscallHintProcessor<'_>,
     implicit_args: Vec<MaybeRelocatable>,
     implicit_args_end: Relocatable,
 ) -> Result<(), PostExecutionError> {

--- a/crates/blockifier/src/execution/deprecated_syscalls/deprecated_syscalls_test.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/deprecated_syscalls_test.rs
@@ -55,7 +55,7 @@ fn test_storage_read_write() {
     };
     let storage_address = entry_point_call.storage_address;
     assert_eq!(
-        entry_point_call.execute_directly(&mut state, None).unwrap().execution,
+        entry_point_call.execute_directly(&mut state).unwrap().execution,
         CallExecution::from_retdata(retdata![stark_felt!(value)])
     );
     // Verify that the state has changed.
@@ -83,7 +83,7 @@ fn test_library_call() {
         ..trivial_external_entry_point_new(test_contract)
     };
     assert_eq!(
-        entry_point_call.execute_directly(&mut state, None).unwrap().execution,
+        entry_point_call.execute_directly(&mut state).unwrap().execution,
         CallExecution::from_retdata(retdata![stark_felt!(91_u16)])
     );
 }
@@ -189,7 +189,7 @@ fn test_nested_library_call() {
         ..Default::default()
     };
 
-    assert_eq!(main_entry_point.execute_directly(&mut state, None).unwrap(), expected_call_info);
+    assert_eq!(main_entry_point.execute_directly(&mut state).unwrap(), expected_call_info);
 }
 
 #[test]
@@ -216,7 +216,7 @@ fn test_call_contract() {
         calldata: calldata.clone(),
         ..trivial_external_entry_point
     };
-    let call_info = entry_point_call.execute_directly(&mut state, None).unwrap();
+    let call_info = entry_point_call.execute_directly(&mut state).unwrap();
 
     let expected_execution = CallExecution { retdata: retdata![value], ..Default::default() };
     let expected_inner_call_info = CallInfo {
@@ -276,7 +276,7 @@ fn test_replace_class() {
         entry_point_selector: selector_from_name("test_replace_class"),
         ..trivial_external_entry_point_new(test_contract)
     };
-    let error = entry_point_call.execute_directly(&mut state, None).unwrap_err().to_string();
+    let error = entry_point_call.execute_directly(&mut state).unwrap_err().to_string();
     assert!(error.contains("is not declared"));
 
     // Positive flow.
@@ -288,7 +288,7 @@ fn test_replace_class() {
         entry_point_selector: selector_from_name("test_replace_class"),
         ..trivial_external_entry_point_new(test_contract)
     };
-    entry_point_call.execute_directly(&mut state, None).unwrap();
+    entry_point_call.execute_directly(&mut state).unwrap();
     assert_eq!(state.get_class_hash_at(test_address).unwrap(), new_class_hash);
 }
 
@@ -360,11 +360,11 @@ fn test_deploy(
 
     if !available_for_deployment {
         // Deploy an instance of the contract for the scenario: deploy_to_unavailable_address.
-        entry_point_call.clone().execute_directly(&mut state, None).unwrap();
+        entry_point_call.clone().execute_directly(&mut state).unwrap();
     }
 
     if let Some(expected_error) = expected_error {
-        let error = entry_point_call.execute_directly(&mut state, None).unwrap_err().to_string();
+        let error = entry_point_call.execute_directly(&mut state).unwrap_err().to_string();
         assert!(error.contains(expected_error.as_str()));
         return;
     }
@@ -378,7 +378,7 @@ fn test_deploy(
     )
     .unwrap();
     assert_eq!(
-        entry_point_call.execute_directly(&mut state, None).unwrap().execution,
+        entry_point_call.execute_directly(&mut state).unwrap().execution,
         CallExecution::from_retdata(retdata![*contract_address.0.key()])
     );
     assert_eq!(state.get_class_hash_at(contract_address).unwrap(), class_hash);
@@ -418,8 +418,7 @@ fn test_block_info_syscalls(
 
     if execution_mode == ExecutionMode::Validate {
         if block_info_member_name == "sequencer_address" {
-            let error =
-                entry_point_call.execute_directly_in_validate_mode(&mut state, None).unwrap_err();
+            let error = entry_point_call.execute_directly_in_validate_mode(&mut state).unwrap_err();
             check_entry_point_execution_error_for_custom_hint!(
                 &error,
                 &format!(
@@ -429,16 +428,13 @@ fn test_block_info_syscalls(
             );
         } else {
             assert_eq!(
-                entry_point_call
-                    .execute_directly_in_validate_mode(&mut state, None)
-                    .unwrap()
-                    .execution,
+                entry_point_call.execute_directly_in_validate_mode(&mut state).unwrap().execution,
                 CallExecution::from_retdata(retdata![])
             );
         }
     } else {
         assert_eq!(
-            entry_point_call.execute_directly(&mut state, None).unwrap().execution,
+            entry_point_call.execute_directly(&mut state).unwrap().execution,
             CallExecution::from_retdata(retdata![])
         );
     }
@@ -484,7 +480,7 @@ fn test_tx_info(#[values(false, true)] only_query: bool) {
     });
     let limit_steps_by_resources = true;
     let result = entry_point_call
-        .execute_directly_given_tx_info(&mut state, tx_info, limit_steps_by_resources, None)
+        .execute_directly_given_tx_info(&mut state, tx_info, limit_steps_by_resources)
         .unwrap();
 
     assert!(!result.execution.failed)
@@ -569,5 +565,5 @@ fn emit_events(
         ..trivial_external_entry_point_new(test_contract)
     };
 
-    entry_point_call.execute_directly(&mut state, None)
+    entry_point_call.execute_directly(&mut state)
 }

--- a/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
@@ -2,7 +2,6 @@ use std::any::Any;
 use std::collections::{HashMap, HashSet};
 
 use cairo_felt::Felt252;
-use cairo_native::cache::ProgramCache;
 use cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::{
     BuiltinHintProcessor, HintProcessorData,
 };
@@ -134,7 +133,7 @@ impl DeprecatedSyscallExecutionError {
 
 /// Executes Starknet syscalls (stateful protocol hints) during the execution of an entry point
 /// call.
-pub struct DeprecatedSyscallHintProcessor<'a, 'context> {
+pub struct DeprecatedSyscallHintProcessor<'a> {
     // Input for execution.
     pub state: &'a mut dyn State,
     pub resources: &'a mut ExecutionResources,
@@ -163,11 +162,9 @@ pub struct DeprecatedSyscallHintProcessor<'a, 'context> {
     // Transaction info. and signature segments; allocated on-demand.
     tx_signature_start_ptr: Option<Relocatable>,
     tx_info_start_ptr: Option<Relocatable>,
-
-    program_cache: &'a mut ProgramCache<'context, ClassHash>,
 }
 
-impl<'a, 'context> DeprecatedSyscallHintProcessor<'a, 'context> {
+impl<'a> DeprecatedSyscallHintProcessor<'a> {
     pub fn new(
         state: &'a mut dyn State,
         resources: &'a mut ExecutionResources,
@@ -175,7 +172,6 @@ impl<'a, 'context> DeprecatedSyscallHintProcessor<'a, 'context> {
         initial_syscall_ptr: Relocatable,
         storage_address: ContractAddress,
         caller_address: ContractAddress,
-        program_cache: &'a mut ProgramCache<'context, ClassHash>,
     ) -> Self {
         DeprecatedSyscallHintProcessor {
             state,
@@ -194,7 +190,6 @@ impl<'a, 'context> DeprecatedSyscallHintProcessor<'a, 'context> {
             builtin_hint_processor: extended_builtin_hint_processor(),
             tx_signature_start_ptr: None,
             tx_info_start_ptr: None,
-            program_cache,
         }
     }
 
@@ -321,7 +316,7 @@ impl<'a, 'context> DeprecatedSyscallHintProcessor<'a, 'context> {
         ExecuteCallback: FnOnce(
             Request,
             &mut VirtualMachine,
-            &mut DeprecatedSyscallHintProcessor<'_, 'context>,
+            &mut DeprecatedSyscallHintProcessor<'_>,
         ) -> DeprecatedSyscallResult<Response>,
     {
         let request = Request::read(vm, &mut self.syscall_ptr)?;
@@ -407,7 +402,7 @@ impl<'a, 'context> DeprecatedSyscallHintProcessor<'a, 'context> {
     }
 }
 
-impl<'context> ResourceTracker for DeprecatedSyscallHintProcessor<'_, 'context> {
+impl<'context> ResourceTracker for DeprecatedSyscallHintProcessor<'_> {
     fn consumed(&self) -> bool {
         self.context.vm_run_resources.consumed()
     }
@@ -425,7 +420,7 @@ impl<'context> ResourceTracker for DeprecatedSyscallHintProcessor<'_, 'context> 
     }
 }
 
-impl<'context> HintProcessorLogic for DeprecatedSyscallHintProcessor<'_, 'context> {
+impl<'context> HintProcessorLogic for DeprecatedSyscallHintProcessor<'_> {
     fn execute_hint(
         &mut self,
         vm: &mut VirtualMachine,
@@ -477,14 +472,10 @@ pub fn read_call_params(
 pub fn execute_inner_call(
     call: CallEntryPoint,
     vm: &mut VirtualMachine,
-    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_, '_>,
+    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<ReadOnlySegment> {
-    let call_info = call.execute(
-        syscall_handler.state,
-        syscall_handler.resources,
-        syscall_handler.context,
-        Some(syscall_handler.program_cache),
-    )?;
+    let call_info =
+        call.execute(syscall_handler.state, syscall_handler.resources, syscall_handler.context)?;
     let retdata = &call_info.execution.retdata.0;
     let retdata: Vec<MaybeRelocatable> =
         retdata.iter().map(|&x| MaybeRelocatable::from(stark_felt_to_felt(x))).collect();
@@ -495,7 +486,7 @@ pub fn execute_inner_call(
 }
 
 pub fn execute_library_call(
-    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_, '_>,
+    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
     vm: &mut VirtualMachine,
     class_hash: ClassHash,
     code_address: Option<ContractAddress>,

--- a/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
@@ -402,7 +402,7 @@ impl<'a> DeprecatedSyscallHintProcessor<'a> {
     }
 }
 
-impl<'context> ResourceTracker for DeprecatedSyscallHintProcessor<'_> {
+impl ResourceTracker for DeprecatedSyscallHintProcessor<'_> {
     fn consumed(&self) -> bool {
         self.context.vm_run_resources.consumed()
     }
@@ -420,7 +420,7 @@ impl<'context> ResourceTracker for DeprecatedSyscallHintProcessor<'_> {
     }
 }
 
-impl<'context> HintProcessorLogic for DeprecatedSyscallHintProcessor<'_> {
+impl HintProcessorLogic for DeprecatedSyscallHintProcessor<'_> {
     fn execute_hint(
         &mut self,
         vm: &mut VirtualMachine,

--- a/crates/blockifier/src/execution/deprecated_syscalls/mod.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/mod.rs
@@ -183,7 +183,7 @@ pub type CallContractResponse = SingleSegmentResponse;
 pub fn call_contract(
     request: CallContractRequest,
     vm: &mut VirtualMachine,
-    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_, '_>,
+    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<CallContractResponse> {
     let storage_address = request.contract_address;
     let class_hash = syscall_handler.state.get_class_hash_at(storage_address)?;
@@ -222,7 +222,7 @@ type DelegateCallResponse = CallContractResponse;
 pub fn delegate_call(
     request: DelegateCallRequest,
     vm: &mut VirtualMachine,
-    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_, '_>,
+    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<DelegateCallResponse> {
     let call_to_external = true;
     let storage_address = request.contract_address;
@@ -245,7 +245,7 @@ pub fn delegate_call(
 pub fn delegate_l1_handler(
     request: DelegateCallRequest,
     vm: &mut VirtualMachine,
-    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_, '_>,
+    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<DelegateCallResponse> {
     let call_to_external = false;
     let storage_address = request.contract_address;
@@ -309,7 +309,7 @@ impl SyscallResponse for DeployResponse {
 pub fn deploy(
     request: DeployRequest,
     _vm: &mut VirtualMachine,
-    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_, '_>,
+    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<DeployResponse> {
     let deployer_address = syscall_handler.storage_address;
     let deployer_address_for_calculation = match request.deploy_from_zero {
@@ -336,7 +336,6 @@ pub fn deploy(
         ctor_context,
         request.constructor_calldata,
         syscall_handler.context.gas_costs().initial_gas_cost,
-        None,
     )?;
     syscall_handler.inner_calls.push(call_info);
 
@@ -371,7 +370,7 @@ type EmitEventResponse = EmptyResponse;
 pub fn emit_event(
     request: EmitEventRequest,
     _vm: &mut VirtualMachine,
-    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_, '_>,
+    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<EmitEventResponse> {
     let execution_context = &mut syscall_handler.context;
     exceeds_event_size_limit(
@@ -406,7 +405,7 @@ impl SyscallResponse for GetBlockNumberResponse {
 pub fn get_block_number(
     _request: GetBlockNumberRequest,
     _vm: &mut VirtualMachine,
-    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_, '_>,
+    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<GetBlockNumberResponse> {
     let versioned_constants = syscall_handler.context.versioned_constants();
     let block_number = syscall_handler.get_block_info().block_number;
@@ -442,7 +441,7 @@ impl SyscallResponse for GetBlockTimestampResponse {
 pub fn get_block_timestamp(
     _request: GetBlockTimestampRequest,
     _vm: &mut VirtualMachine,
-    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_, '_>,
+    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<GetBlockTimestampResponse> {
     let versioned_constants = syscall_handler.context.versioned_constants();
     let block_timestamp = syscall_handler.get_block_info().block_timestamp;
@@ -466,7 +465,7 @@ type GetCallerAddressResponse = GetContractAddressResponse;
 pub fn get_caller_address(
     _request: GetCallerAddressRequest,
     _vm: &mut VirtualMachine,
-    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_, '_>,
+    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<GetCallerAddressResponse> {
     Ok(GetCallerAddressResponse { address: syscall_handler.caller_address })
 }
@@ -490,7 +489,7 @@ impl SyscallResponse for GetContractAddressResponse {
 pub fn get_contract_address(
     _request: GetContractAddressRequest,
     _vm: &mut VirtualMachine,
-    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_, '_>,
+    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<GetContractAddressResponse> {
     Ok(GetContractAddressResponse { address: syscall_handler.storage_address })
 }
@@ -503,7 +502,7 @@ type GetSequencerAddressResponse = GetContractAddressResponse;
 pub fn get_sequencer_address(
     _request: GetSequencerAddressRequest,
     _vm: &mut VirtualMachine,
-    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_, '_>,
+    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<GetSequencerAddressResponse> {
     syscall_handler.verify_not_in_validate_mode("get_sequencer_address")?;
     Ok(GetSequencerAddressResponse { address: syscall_handler.get_block_info().sequencer_address })
@@ -527,7 +526,7 @@ impl SyscallResponse for GetTxInfoResponse {
 pub fn get_tx_info(
     _request: GetTxInfoRequest,
     vm: &mut VirtualMachine,
-    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_, '_>,
+    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<GetTxInfoResponse> {
     let tx_info_start_ptr = syscall_handler.get_or_allocate_tx_info_start_ptr(vm)?;
 
@@ -542,7 +541,7 @@ type GetTxSignatureResponse = SingleSegmentResponse;
 pub fn get_tx_signature(
     _request: GetTxSignatureRequest,
     vm: &mut VirtualMachine,
-    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_, '_>,
+    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<GetTxSignatureResponse> {
     let start_ptr = syscall_handler.get_or_allocate_tx_signature_segment(vm)?;
     let length = syscall_handler.context.tx_context.tx_info.signature().0.len();
@@ -576,7 +575,7 @@ type LibraryCallResponse = CallContractResponse;
 pub fn library_call(
     request: LibraryCallRequest,
     vm: &mut VirtualMachine,
-    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_, '_>,
+    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<LibraryCallResponse> {
     let call_to_external = true;
     let retdata_segment = execute_library_call(
@@ -597,7 +596,7 @@ pub fn library_call(
 pub fn library_call_l1_handler(
     request: LibraryCallRequest,
     vm: &mut VirtualMachine,
-    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_, '_>,
+    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<LibraryCallResponse> {
     let call_to_external = false;
     let retdata_segment = execute_library_call(
@@ -636,7 +635,7 @@ pub type ReplaceClassResponse = EmptyResponse;
 pub fn replace_class(
     request: ReplaceClassRequest,
     _vm: &mut VirtualMachine,
-    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_, '_>,
+    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<ReplaceClassResponse> {
     // Ensure the class is declared (by reading it).
     syscall_handler.state.get_compiled_contract_class(request.class_hash)?;
@@ -670,7 +669,7 @@ type SendMessageToL1Response = EmptyResponse;
 pub fn send_message_to_l1(
     request: SendMessageToL1Request,
     _vm: &mut VirtualMachine,
-    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_, '_>,
+    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<SendMessageToL1Response> {
     let execution_context = &mut syscall_handler.context;
     let ordered_message_to_l1 = OrderedL2ToL1Message {
@@ -715,7 +714,7 @@ impl SyscallResponse for StorageReadResponse {
 pub fn storage_read(
     request: StorageReadRequest,
     _vm: &mut VirtualMachine,
-    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_, '_>,
+    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<StorageReadResponse> {
     syscall_handler.get_contract_storage_at(request.address)
 }
@@ -744,7 +743,7 @@ pub type StorageWriteResponse = EmptyResponse;
 pub fn storage_write(
     request: StorageWriteRequest,
     _vm: &mut VirtualMachine,
-    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_, '_>,
+    syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<StorageWriteResponse> {
     syscall_handler.set_contract_storage_at(request.address, request.value)
 }

--- a/crates/blockifier/src/execution/entry_point_test.rs
+++ b/crates/blockifier/src/execution/entry_point_test.rs
@@ -590,7 +590,7 @@ fn get_entry_point_offset(
                 .unwrap()
                 .offset
         }
-        ContractClass::V1Sierra(_) => {
+        ContractClass::V1Native(_) => {
             panic!("Expected V0 or V1, found V1Sierra in entry point tests")
         }
     }

--- a/crates/blockifier/src/execution/entry_point_test.rs
+++ b/crates/blockifier/src/execution/entry_point_test.rs
@@ -86,7 +86,7 @@ fn test_entry_point_without_arg() {
         ..trivial_external_entry_point_new(test_contract)
     };
     assert_eq!(
-        entry_point_call.execute_directly(&mut state, None).unwrap().execution,
+        entry_point_call.execute_directly(&mut state).unwrap().execution,
         CallExecution::default()
     );
 }
@@ -102,7 +102,7 @@ fn test_entry_point_with_arg() {
         ..trivial_external_entry_point_new(test_contract)
     };
     assert_eq!(
-        entry_point_call.execute_directly(&mut state, None).unwrap().execution,
+        entry_point_call.execute_directly(&mut state).unwrap().execution,
         CallExecution::default()
     );
 }
@@ -118,7 +118,7 @@ fn test_long_retdata() {
         ..trivial_external_entry_point_new(test_contract)
     };
     assert_eq!(
-        entry_point_call.execute_directly(&mut state, None).unwrap().execution,
+        entry_point_call.execute_directly(&mut state).unwrap().execution,
         CallExecution::from_retdata(retdata![
             stark_felt!(0_u8),
             stark_felt!(1_u8),
@@ -140,7 +140,7 @@ fn test_entry_point_with_builtin() {
         ..trivial_external_entry_point_new(test_contract)
     };
     assert_eq!(
-        entry_point_call.execute_directly(&mut state, None).unwrap().execution,
+        entry_point_call.execute_directly(&mut state).unwrap().execution,
         CallExecution::default()
     );
 }
@@ -156,7 +156,7 @@ fn test_entry_point_with_hint() {
         ..trivial_external_entry_point_new(test_contract)
     };
     assert_eq!(
-        entry_point_call.execute_directly(&mut state, None).unwrap().execution,
+        entry_point_call.execute_directly(&mut state).unwrap().execution,
         CallExecution::default()
     );
 }
@@ -172,7 +172,7 @@ fn test_entry_point_with_return_value() {
         ..trivial_external_entry_point_new(test_contract)
     };
     assert_eq!(
-        entry_point_call.execute_directly(&mut state, None).unwrap().execution,
+        entry_point_call.execute_directly(&mut state).unwrap().execution,
         CallExecution::from_retdata(retdata![stark_felt!(23_u8)])
     );
 }
@@ -184,7 +184,7 @@ fn test_entry_point_not_found_in_contract() {
     let entry_point_selector = EntryPointSelector(stark_felt!(2_u8));
     let entry_point_call =
         CallEntryPoint { entry_point_selector, ..trivial_external_entry_point_new(test_contract) };
-    let error = entry_point_call.execute_directly(&mut state, None).unwrap_err();
+    let error = entry_point_call.execute_directly(&mut state).unwrap_err();
     assert_eq!(
         format!("Entry point {entry_point_selector:?} not found in contract."),
         format!("{error}")
@@ -200,7 +200,7 @@ fn test_storage_var() {
         ..trivial_external_entry_point_new(test_contract)
     };
     assert_eq!(
-        entry_point_call.execute_directly(&mut state, None).unwrap().execution,
+        entry_point_call.execute_directly(&mut state).unwrap().execution,
         CallExecution::default()
     );
 }
@@ -221,7 +221,7 @@ fn run_security_test(
         initial_gas: versioned_constants.os_constants.gas_costs.initial_gas_cost,
         ..Default::default()
     };
-    let error = match entry_point_call.execute_directly(state, None) {
+    let error = match entry_point_call.execute_directly(state) {
         Err(error) => error.to_string(),
         Ok(_) => panic!(
             "Entry point '{entry_point_name}' did not fail! Expected error: {expected_error}"
@@ -519,7 +519,7 @@ fn test_storage_related_members() {
         entry_point_selector: selector_from_name("test_storage_var"),
         ..trivial_external_entry_point_new(test_contract)
     };
-    let actual_call_info = entry_point_call.execute_directly(&mut state, None).unwrap();
+    let actual_call_info = entry_point_call.execute_directly(&mut state).unwrap();
     assert_eq!(actual_call_info.storage_read_values, vec![stark_felt!(39_u8)]);
     assert_eq!(
         actual_call_info.accessed_storage_keys,
@@ -535,7 +535,7 @@ fn test_storage_related_members() {
         entry_point_selector: selector_from_name("test_storage_read_write"),
         ..trivial_external_entry_point_new(test_contract)
     };
-    let actual_call_info = entry_point_call.execute_directly(&mut state, None).unwrap();
+    let actual_call_info = entry_point_call.execute_directly(&mut state).unwrap();
     assert_eq!(actual_call_info.storage_read_values, vec![value]);
     assert_eq!(actual_call_info.accessed_storage_keys, HashSet::from([storage_key!(key)]));
 }
@@ -552,14 +552,12 @@ fn test_cairo1_entry_point_segment_arena() {
         ..trivial_external_entry_point_new(test_contract)
     };
 
-    assert!(
-        entry_point_call
-            .execute_directly(&mut state, None)
-            .unwrap()
-            .resources
-            .builtin_instance_counter
-            .contains_key(BuiltinName::segment_arena.name())
-    );
+    assert!(entry_point_call
+        .execute_directly(&mut state)
+        .unwrap()
+        .resources
+        .builtin_instance_counter
+        .contains_key(BuiltinName::segment_arena.name()));
 }
 
 /// Fetch PC locations from the compiled contract to compute the expected PC locations in the
@@ -1091,7 +1089,7 @@ Execution failed. Failure reason: 0x496e76616c6964207363656e6172696f ('Invalid s
     // Clean pc locations from the trace.
     let re = Regex::new(r"pc=0:[0-9]+").unwrap();
     let cleaned_expected_error = &re.replace_all(&expected_error, "pc=0:*");
-    let actual_error = account_tx.execute(state, block_context, true, true, None).unwrap_err();
+    let actual_error = account_tx.execute(state, block_context, true, true).unwrap_err();
     let actual_error_str = actual_error.to_string();
     let cleaned_actual_error = &re.replace_all(&actual_error_str, "pc=0:*");
     // Compare actual trace to the expected trace (sans pc locations).

--- a/crates/blockifier/src/execution/entry_point_test.rs
+++ b/crates/blockifier/src/execution/entry_point_test.rs
@@ -552,12 +552,14 @@ fn test_cairo1_entry_point_segment_arena() {
         ..trivial_external_entry_point_new(test_contract)
     };
 
-    assert!(entry_point_call
-        .execute_directly(&mut state)
-        .unwrap()
-        .resources
-        .builtin_instance_counter
-        .contains_key(BuiltinName::segment_arena.name()));
+    assert!(
+        entry_point_call
+            .execute_directly(&mut state)
+            .unwrap()
+            .resources
+            .builtin_instance_counter
+            .contains_key(BuiltinName::segment_arena.name())
+    );
 }
 
 /// Fetch PC locations from the compiled contract to compute the expected PC locations in the

--- a/crates/blockifier/src/execution/execution_utils.rs
+++ b/crates/blockifier/src/execution/execution_utils.rs
@@ -76,7 +76,7 @@ pub fn execute_entry_point_call(
             resources,
             context,
         ),
-        ContractClass::V1Sierra(contract_class) => {
+        ContractClass::V1Native(contract_class) => {
             let fallback = env::var("FALLBACK_ENABLED").unwrap_or(String::from("0")) == "1";
             match native_entry_point_execution::execute_entry_point_call(
                 call.clone(),

--- a/crates/blockifier/src/execution/execution_utils.rs
+++ b/crates/blockifier/src/execution/execution_utils.rs
@@ -328,11 +328,7 @@ pub fn format_panic_data(felts: &[StarkFelt]) -> String {
     while let Some(item) = format_next_item(&mut felts) {
         items.push(item.quote_if_string());
     }
-    if let [item] = &items[..] {
-        item.clone()
-    } else {
-        format!("({})", items.join(", "))
-    }
+    if let [item] = &items[..] { item.clone() } else { format!("({})", items.join(", ")) }
 }
 
 /// Returns the VM resources required for running `poseidon_hash_many` in the Starknet OS.

--- a/crates/blockifier/src/execution/execution_utils.rs
+++ b/crates/blockifier/src/execution/execution_utils.rs
@@ -3,7 +3,6 @@ use std::env;
 
 use cairo_felt::Felt252;
 use cairo_lang_runner::casm_run::format_next_item;
-use cairo_native::cache::ProgramCache;
 use cairo_vm::serde::deserialize_program::{
     deserialize_array_of_bigint_hex, Attribute, HintParams, Identifier, ReferenceManager,
 };
@@ -59,7 +58,6 @@ pub fn execute_entry_point_call(
     state: &mut dyn State,
     resources: &mut ExecutionResources,
     context: &mut EntryPointExecutionContext,
-    program_cache: &mut ProgramCache<'_, ClassHash>,
 ) -> EntryPointExecutionResult<CallInfo> {
     match contract_class {
         ContractClass::V0(contract_class) => {
@@ -69,7 +67,6 @@ pub fn execute_entry_point_call(
                 state,
                 resources,
                 context,
-                program_cache,
             )
         }
         ContractClass::V1(contract_class) => entry_point_execution::execute_entry_point_call(
@@ -87,7 +84,6 @@ pub fn execute_entry_point_call(
                 state,
                 resources,
                 context,
-                program_cache,
             ) {
                 Ok(res) => Ok(res),
                 Err(EntryPointExecutionError::NativeUnexpectedError { .. }) if fallback => {
@@ -262,7 +258,6 @@ pub fn execute_deployment(
     ctor_context: ConstructorContext,
     constructor_calldata: Calldata,
     remaining_gas: u64,
-    program_cache: Option<&mut ProgramCache<'_, ClassHash>>,
 ) -> ConstructorEntryPointExecutionResult<CallInfo> {
     // Address allocation in the state is done before calling the constructor, so that it is
     // visible from it.
@@ -290,7 +285,6 @@ pub fn execute_deployment(
         ctor_context,
         constructor_calldata,
         remaining_gas,
-        program_cache,
     )
 }
 
@@ -334,7 +328,11 @@ pub fn format_panic_data(felts: &[StarkFelt]) -> String {
     while let Some(item) = format_next_item(&mut felts) {
         items.push(item.quote_if_string());
     }
-    if let [item] = &items[..] { item.clone() } else { format!("({})", items.join(", ")) }
+    if let [item] = &items[..] {
+        item.clone()
+    } else {
+        format!("({})", items.join(", "))
+    }
 }
 
 /// Returns the VM resources required for running `poseidon_hash_many` in the Starknet OS.

--- a/crates/blockifier/src/execution/native/entry_point_execution.rs
+++ b/crates/blockifier/src/execution/native/entry_point_execution.rs
@@ -1,9 +1,7 @@
 use cairo_lang_sierra::program::Program as SierraProgram;
 use cairo_lang_starknet_classes::contract_class::ContractEntryPoints;
-use cairo_native::cache::ProgramCache;
 use cairo_native::executor::NativeExecutor;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
-use starknet_api::core::ClassHash;
 
 use super::syscall_handler::NativeSyscallHandler;
 use super::utils::{get_sierra_entry_function_id, match_entrypoint, run_native_executor};
@@ -20,7 +18,6 @@ pub fn execute_entry_point_call(
     state: &mut dyn State,
     resources: &mut ExecutionResources,
     context: &mut EntryPointExecutionContext,
-    program_cache: &mut ProgramCache<'_, ClassHash>,
 ) -> EntryPointExecutionResult<CallInfo> {
     let sierra_program: &SierraProgram = &contract_class.sierra_program();
     let contract_entrypoints: &ContractEntryPoints = &contract_class.entry_points_by_type;
@@ -28,14 +25,13 @@ pub fn execute_entry_point_call(
     let matching_entrypoint =
         match_entrypoint(call.entry_point_type, call.entry_point_selector, contract_entrypoints)?;
 
-    let syscall_handler: NativeSyscallHandler<'_, '_> = NativeSyscallHandler::new(
+    let syscall_handler: NativeSyscallHandler<'_> = NativeSyscallHandler::new(
         state,
         call.caller_address,
         call.storage_address,
         call.entry_point_selector,
         resources,
         context,
-        program_cache,
     );
 
     let sierra_entry_function_id =

--- a/crates/blockifier/src/execution/native/entry_point_execution.rs
+++ b/crates/blockifier/src/execution/native/entry_point_execution.rs
@@ -1,6 +1,5 @@
 use cairo_lang_sierra::program::Program as SierraProgram;
 use cairo_lang_starknet_classes::contract_class::ContractEntryPoints;
-use cairo_native::executor::NativeExecutor;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 
 use super::syscall_handler::NativeSyscallHandler;
@@ -39,7 +38,7 @@ pub fn execute_entry_point_call(
 
     println!("Blockifier-Native: running the Native Executor");
     let result = run_native_executor(
-        NativeExecutor::Aot(contract_class.executor.clone()),
+        &contract_class.executor,
         sierra_entry_function_id,
         call,
         syscall_handler,

--- a/crates/blockifier/src/execution/native/entry_point_execution.rs
+++ b/crates/blockifier/src/execution/native/entry_point_execution.rs
@@ -19,7 +19,7 @@ pub fn execute_entry_point_call(
     resources: &mut ExecutionResources,
     context: &mut EntryPointExecutionContext,
 ) -> EntryPointExecutionResult<CallInfo> {
-    let sierra_program: &SierraProgram = &contract_class.sierra_program();
+    let sierra_program: &SierraProgram = &contract_class.sierra_program;
     let contract_entrypoints: &ContractEntryPoints = &contract_class.entry_points_by_type;
 
     let matching_entrypoint =

--- a/crates/blockifier/src/execution/native/entry_point_execution.rs
+++ b/crates/blockifier/src/execution/native/entry_point_execution.rs
@@ -5,7 +5,7 @@ use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use super::syscall_handler::NativeSyscallHandler;
 use super::utils::{get_sierra_entry_function_id, match_entrypoint, run_native_executor};
 use crate::execution::call_info::CallInfo;
-use crate::execution::contract_class::SierraContractClassV1;
+use crate::execution::contract_class::NativeContractClassV1;
 use crate::execution::entry_point::{
     CallEntryPoint, EntryPointExecutionContext, EntryPointExecutionResult,
 };
@@ -13,7 +13,7 @@ use crate::state::state_api::State;
 
 pub fn execute_entry_point_call(
     call: CallEntryPoint,
-    contract_class: SierraContractClassV1,
+    contract_class: NativeContractClassV1,
     state: &mut dyn State,
     resources: &mut ExecutionResources,
     context: &mut EntryPointExecutionContext,

--- a/crates/blockifier/src/execution/native/syscall_handler.rs
+++ b/crates/blockifier/src/execution/native/syscall_handler.rs
@@ -4,7 +4,6 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use ark_ec::short_weierstrass::{Affine, Projective, SWCurveConfig};
-use cairo_native::cache::ProgramCache;
 use cairo_native::starknet::{
     BlockInfo, ExecutionInfoV2, Secp256k1Point, Secp256r1Point, StarknetSyscallHandler,
     SyscallResult, TxInfo, TxV2Info, U256,
@@ -43,7 +42,7 @@ use crate::execution::syscalls::hint_processor::{
 };
 use crate::state::state_api::State;
 use crate::transaction::objects::TransactionInfo;
-pub struct NativeSyscallHandler<'state, 'native> {
+pub struct NativeSyscallHandler<'state> {
     // Input for execution
     pub state: &'state mut dyn State,
     pub execution_resources: &'state mut ExecutionResources,
@@ -61,11 +60,9 @@ pub struct NativeSyscallHandler<'state, 'native> {
     // Additional execution result info
     pub storage_read_values: Vec<StarkFelt>,
     pub accessed_storage_keys: HashSet<StorageKey, RandomState>,
-
-    pub program_cache: &'state mut ProgramCache<'native, ClassHash>,
 }
 
-impl<'state, 'native> NativeSyscallHandler<'state, 'native> {
+impl<'state> NativeSyscallHandler<'state> {
     pub fn new(
         state: &'state mut dyn State,
         caller_address: ContractAddress,
@@ -73,8 +70,7 @@ impl<'state, 'native> NativeSyscallHandler<'state, 'native> {
         entry_point_selector: EntryPointSelector,
         execution_resources: &'state mut ExecutionResources,
         execution_context: &'state mut EntryPointExecutionContext,
-        program_cache: &'state mut ProgramCache<'native, ClassHash>,
-    ) -> NativeSyscallHandler<'state, 'native> {
+    ) -> NativeSyscallHandler<'state> {
         NativeSyscallHandler {
             state,
             caller_address,
@@ -87,12 +83,11 @@ impl<'state, 'native> NativeSyscallHandler<'state, 'native> {
             inner_calls: Vec::new(),
             storage_read_values: Vec::new(),
             accessed_storage_keys: HashSet::new(),
-            program_cache,
         }
     }
 }
 
-impl<'state, 'native> StarknetSyscallHandler for &mut NativeSyscallHandler<'state, 'native> {
+impl<'state, 'native> StarknetSyscallHandler for &mut NativeSyscallHandler<'state> {
     fn get_block_hash(
         &mut self,
         block_number: u64,
@@ -325,7 +320,6 @@ impl<'state, 'native> StarknetSyscallHandler for &mut NativeSyscallHandler<'stat
             ctor_context,
             wrapper_calldata,
             u64::try_from(*remaining_gas).unwrap(),
-            Some(self.program_cache),
         )
         .map_err(|error| encode_str_as_felts(&error.to_string()))?;
 
@@ -395,12 +389,7 @@ impl<'state, 'native> StarknetSyscallHandler for &mut NativeSyscallHandler<'stat
         };
 
         let call_info = entry_point
-            .execute(
-                self.state,
-                self.execution_resources,
-                self.execution_context,
-                Some(self.program_cache),
-            )
+            .execute(self.state, self.execution_resources, self.execution_context)
             .map_err(|e| encode_str_as_felts(&e.to_string()))?;
 
         let retdata = call_info
@@ -459,12 +448,7 @@ impl<'state, 'native> StarknetSyscallHandler for &mut NativeSyscallHandler<'stat
         };
 
         let call_info = entry_point
-            .execute(
-                self.state,
-                self.execution_resources,
-                self.execution_context,
-                Some(self.program_cache),
-            )
+            .execute(self.state, self.execution_resources, self.execution_context)
             .map_err(|e| encode_str_as_felts(&e.to_string()))?;
 
         let retdata = call_info

--- a/crates/blockifier/src/execution/native/syscall_handler.rs
+++ b/crates/blockifier/src/execution/native/syscall_handler.rs
@@ -347,7 +347,7 @@ impl<'state> StarknetSyscallHandler for &mut NativeSyscallHandler<'state> {
             ContractClass::V0(_) => Err(encode_str_as_felts(
                 &SyscallExecutionError::ForbiddenClassReplacement { class_hash }.to_string(),
             )),
-            ContractClass::V1(_) | ContractClass::V1Sierra(_) => {
+            ContractClass::V1(_) | ContractClass::V1Native(_) => {
                 self.state
                     .set_class_hash_at(self.contract_address, class_hash)
                     .map_err(|e| encode_str_as_felts(&e.to_string()))?;

--- a/crates/blockifier/src/execution/native/syscall_handler.rs
+++ b/crates/blockifier/src/execution/native/syscall_handler.rs
@@ -87,7 +87,7 @@ impl<'state> NativeSyscallHandler<'state> {
     }
 }
 
-impl<'state, 'native> StarknetSyscallHandler for &mut NativeSyscallHandler<'state> {
+impl<'state> StarknetSyscallHandler for &mut NativeSyscallHandler<'state> {
     fn get_block_hash(
         &mut self,
         block_number: u64,

--- a/crates/blockifier/src/execution/native/utils.rs
+++ b/crates/blockifier/src/execution/native/utils.rs
@@ -5,7 +5,7 @@ use ark_ff::BigInt;
 use cairo_lang_sierra::ids::FunctionId;
 use cairo_lang_sierra::program::Program as SierraProgram;
 use cairo_lang_starknet_classes::contract_class::{ContractEntryPoint, ContractEntryPoints};
-use cairo_native::cache::{AotProgramCache, JitProgramCache, ProgramCache};
+use cairo_native::cache::{AotProgramCache, ProgramCache};
 use cairo_native::context::NativeContext;
 use cairo_native::execution_result::ContractExecutionResult;
 use cairo_native::executor::NativeExecutor;
@@ -72,16 +72,8 @@ pub fn match_entrypoint(
 static NATIVE_CONTEXT: std::sync::OnceLock<cairo_native::context::NativeContext> =
     std::sync::OnceLock::new();
 
-pub fn get_native_aot_program_cache<'context>() -> ProgramCache<'context, ClassHash> {
-    ProgramCache::Aot(AotProgramCache::new(NATIVE_CONTEXT.get_or_init(NativeContext::new)))
-}
-
-pub fn get_native_aot_program_cache_aot<'context>() -> AotProgramCache<'context, ClassHash> {
+pub fn get_native_aot_program_cache<'context>() -> AotProgramCache<'context, ClassHash> {
     AotProgramCache::new(NATIVE_CONTEXT.get_or_init(NativeContext::new))
-}
-
-pub fn get_native_jit_program_cache<'context>() -> ProgramCache<'context, ClassHash> {
-    ProgramCache::Jit(JitProgramCache::new(NATIVE_CONTEXT.get_or_init(NativeContext::new)))
 }
 
 pub fn get_native_executor<'context>(

--- a/crates/blockifier/src/execution/native/utils.rs
+++ b/crates/blockifier/src/execution/native/utils.rs
@@ -76,6 +76,10 @@ pub fn get_native_aot_program_cache<'context>() -> ProgramCache<'context, ClassH
     ProgramCache::Aot(AotProgramCache::new(NATIVE_CONTEXT.get_or_init(NativeContext::new)))
 }
 
+pub fn get_native_aot_program_cache_aot<'context>() -> AotProgramCache<'context, ClassHash> {
+    AotProgramCache::new(NATIVE_CONTEXT.get_or_init(NativeContext::new))
+}
+
 pub fn get_native_jit_program_cache<'context>() -> ProgramCache<'context, ClassHash> {
     ProgramCache::Jit(JitProgramCache::new(NATIVE_CONTEXT.get_or_init(NativeContext::new)))
 }

--- a/crates/blockifier/src/execution/native/utils.rs
+++ b/crates/blockifier/src/execution/native/utils.rs
@@ -154,7 +154,7 @@ pub fn run_native_executor(
     native_executor: NativeExecutor<'_>,
     sierra_entry_function_id: &FunctionId,
     call: CallEntryPoint,
-    mut syscall_handler: NativeSyscallHandler<'_, '_>,
+    mut syscall_handler: NativeSyscallHandler<'_>,
 ) -> EntryPointExecutionResult<CallInfo> {
     let stark_felts_to_native_felts = |data: &[StarkFelt]| -> Vec<Felt> {
         data.iter().map(|stark_felt| stark_felt_to_native_felt(*stark_felt)).collect_vec()

--- a/crates/blockifier/src/execution/syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/syscalls/hint_processor.rs
@@ -768,12 +768,8 @@ pub fn execute_inner_call(
     syscall_handler: &mut SyscallHintProcessor<'_>,
     remaining_gas: &mut u64,
 ) -> SyscallResult<ReadOnlySegment> {
-    let call_info = call.execute(
-        syscall_handler.state,
-        syscall_handler.resources,
-        syscall_handler.context,
-        None,
-    )?;
+    let call_info =
+        call.execute(syscall_handler.state, syscall_handler.resources, syscall_handler.context)?;
     let raw_retdata = &call_info.execution.retdata.0;
 
     if call_info.execution.failed {

--- a/crates/blockifier/src/execution/syscalls/mod.rs
+++ b/crates/blockifier/src/execution/syscalls/mod.rs
@@ -524,7 +524,7 @@ pub fn replace_class(
         ContractClass::V0(_) => {
             Err(SyscallExecutionError::ForbiddenClassReplacement { class_hash })
         }
-        ContractClass::V1(_) | ContractClass::V1Sierra(_) => {
+        ContractClass::V1(_) | ContractClass::V1Native(_) => {
             syscall_handler
                 .state
                 .set_class_hash_at(syscall_handler.storage_address(), class_hash)?;

--- a/crates/blockifier/src/execution/syscalls/mod.rs
+++ b/crates/blockifier/src/execution/syscalls/mod.rs
@@ -259,7 +259,6 @@ pub fn deploy(
         ctor_context,
         request.constructor_calldata,
         *remaining_gas,
-        None,
     )?;
 
     let constructor_retdata =
@@ -688,10 +687,8 @@ pub fn keccak(
 
     if remainder != 0 {
         return Err(SyscallExecutionError::SyscallError {
-            error_data: vec![
-                StarkFelt::try_from(INVALID_INPUT_LENGTH_ERROR)
-                    .map_err(SyscallExecutionError::from)?,
-            ],
+            error_data: vec![StarkFelt::try_from(INVALID_INPUT_LENGTH_ERROR)
+                .map_err(SyscallExecutionError::from)?],
         });
     }
 

--- a/crates/blockifier/src/execution/syscalls/mod.rs
+++ b/crates/blockifier/src/execution/syscalls/mod.rs
@@ -687,8 +687,10 @@ pub fn keccak(
 
     if remainder != 0 {
         return Err(SyscallExecutionError::SyscallError {
-            error_data: vec![StarkFelt::try_from(INVALID_INPUT_LENGTH_ERROR)
-                .map_err(SyscallExecutionError::from)?],
+            error_data: vec![
+                StarkFelt::try_from(INVALID_INPUT_LENGTH_ERROR)
+                    .map_err(SyscallExecutionError::from)?,
+            ],
         });
     }
 

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/call_contract.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/call_contract.rs
@@ -65,7 +65,7 @@ fn test_call_contract(
     };
 
     assert_eq!(
-        entry_point_call.execute_directly(&mut state, None).unwrap().execution,
+        entry_point_call.execute_directly(&mut state).unwrap().execution,
         CallExecution {
             retdata: retdata![stark_felt!(48_u8)],
             gas_consumed: expected_gas,

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/deploy.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/deploy.rs
@@ -48,7 +48,7 @@ fn no_constructor(deployer_contract: FeatureContract) {
     )
     .unwrap();
 
-    let deploy_call = &entry_point_call.execute_directly(&mut state, None).unwrap().inner_calls[0];
+    let deploy_call = &entry_point_call.execute_directly(&mut state).unwrap().inner_calls[0];
     assert_eq!(deploy_call.call.storage_address, deployed_contract_address);
     assert_eq!(
         deploy_call.execution,
@@ -82,7 +82,7 @@ fn no_constructor_nonempty_calldata(deployer_contract: FeatureContract) {
         ..trivial_external_entry_point_new(deployer_contract)
     };
 
-    let error = entry_point_call.execute_directly(&mut state, None).unwrap_err().to_string();
+    let error = entry_point_call.execute_directly(&mut state).unwrap_err().to_string();
     assert!(error.contains(
         "Invalid input: constructor_calldata; Cannot pass calldata to a contract with no \
          constructor."
@@ -125,7 +125,7 @@ fn with_constructor(deployer_contract: FeatureContract, expected_gas: u64) {
         deployer_contract.get_instance_address(0),
     )
     .unwrap();
-    let deploy_call = &entry_point_call.execute_directly(&mut state, None).unwrap().inner_calls[0];
+    let deploy_call = &entry_point_call.execute_directly(&mut state).unwrap().inner_calls[0];
     assert_eq!(deploy_call.call.storage_address, contract_address);
     assert_eq!(
         deploy_call.execution,
@@ -166,9 +166,9 @@ fn to_unavailable_address(deployer_contract: FeatureContract) {
         ..trivial_external_entry_point_new(deployer_contract)
     };
 
-    entry_point_call.clone().execute_directly(&mut state, None).unwrap();
+    entry_point_call.clone().execute_directly(&mut state).unwrap();
 
-    let error = entry_point_call.execute_directly(&mut state, None).unwrap_err().to_string();
+    let error = entry_point_call.execute_directly(&mut state).unwrap_err().to_string();
     assert!(error.contains("is unavailable for deployment."));
     assert_consistent_contract_version(deployer_contract, &state);
     assert_consistent_contract_version(empty_contract, &state);

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/emit_event.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/emit_event.rs
@@ -118,7 +118,7 @@ fn emit_events(
         ..trivial_external_entry_point_new(test_contract)
     };
 
-    let result = entry_point_call.execute_directly(&mut state, None);
+    let result = entry_point_call.execute_directly(&mut state);
     assert_consistent_contract_version(test_contract, &state);
     result
 }

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/get_block_hash.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/get_block_hash.rs
@@ -55,7 +55,7 @@ fn positive_flow(test_contract: FeatureContract, expected_gas: u64) {
     };
 
     assert_eq!(
-        entry_point_call.clone().execute_directly(&mut state, None).unwrap().execution,
+        entry_point_call.clone().execute_directly(&mut state).unwrap().execution,
         CallExecution {
             gas_consumed: expected_gas,
             ..CallExecution::from_retdata(retdata![block_hash])
@@ -76,10 +76,8 @@ fn negative_flow_execution_mode_validate(test_contract: FeatureContract) {
         ..trivial_external_entry_point_new(test_contract)
     };
 
-    let error = entry_point_call
-        .execute_directly_in_validate_mode(&mut state, None)
-        .unwrap_err()
-        .to_string();
+    let error =
+        entry_point_call.execute_directly_in_validate_mode(&mut state).unwrap_err().to_string();
     // check_entry_point_execution_error_for_custom_hint!(
     //     &error,
     //     "Unauthorized syscall get_block_hash in execution mode Validate.",
@@ -102,7 +100,7 @@ fn negative_flow_block_number_out_of_range(test_contract: FeatureContract) {
         ..trivial_external_entry_point_new(test_contract)
     };
 
-    let error = entry_point_call.execute_directly(&mut state, None).unwrap_err().to_string();
+    let error = entry_point_call.execute_directly(&mut state).unwrap_err().to_string();
     assert!(error.contains("Block number out of range"));
     assert_consistent_contract_version(test_contract, &state);
 }

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/get_execution_info.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/get_execution_info.rs
@@ -296,10 +296,11 @@ fn test_get_execution_info(
     };
 
     let result = match execution_mode {
-        ExecutionMode::Validate => entry_point_call
-            .execute_directly_given_tx_info_in_validate_mode(state, tx_info, false, None),
+        ExecutionMode::Validate => {
+            entry_point_call.execute_directly_given_tx_info_in_validate_mode(state, tx_info, false)
+        }
         ExecutionMode::Execute => {
-            entry_point_call.execute_directly_given_tx_info(state, tx_info, false, None)
+            entry_point_call.execute_directly_given_tx_info(state, tx_info, false)
         }
     };
 

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/keccak.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/keccak.rs
@@ -25,7 +25,7 @@ fn test_keccak(test_contract: FeatureContract, expected_gas: u64) {
     };
 
     assert_eq!(
-        entry_point_call.execute_directly(&mut state, None).unwrap().execution,
+        entry_point_call.execute_directly(&mut state).unwrap().execution,
         CallExecution { gas_consumed: expected_gas, ..CallExecution::from_retdata(retdata![]) }
     );
 }

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/library_call.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/library_call.rs
@@ -49,7 +49,7 @@ fn test_library_call(test_contract: FeatureContract, expected_gas: u64) {
     };
 
     assert_eq!(
-        entry_point_call.execute_directly(&mut state, None).unwrap().execution,
+        entry_point_call.execute_directly(&mut state).unwrap().execution,
         CallExecution {
             retdata: retdata![stark_felt!(91_u16)],
             gas_consumed: expected_gas,
@@ -78,7 +78,7 @@ fn test_library_call_assert_fails(test_contract: FeatureContract) {
         ..trivial_external_entry_point_new(test_contract)
     };
 
-    let err = entry_point_call.execute_directly(&mut state, None).unwrap_err();
+    let err = entry_point_call.execute_directly(&mut state).unwrap_err();
     assert!(err.to_string().contains("x != y"));
 }
 
@@ -103,7 +103,11 @@ fn test_nested_library_call(test_contract: FeatureContract, expected_gas: u64) {
     // Todo(rodrigo): Execution resources from the VM & Native are mesaured differently
     // helper function to change the expected resource values from both of executions
     let if_sierra = |a, b| {
-        if matches!(test_contract, FeatureContract::SierraTestContract) { a } else { b }
+        if matches!(test_contract, FeatureContract::SierraTestContract) {
+            a
+        } else {
+            b
+        }
     };
 
     // Create expected call info tree.
@@ -231,5 +235,5 @@ fn test_nested_library_call(test_contract: FeatureContract, expected_gas: u64) {
         ..Default::default()
     };
 
-    assert_eq!(main_entry_point.execute_directly(&mut state, None).unwrap(), expected_call_info);
+    assert_eq!(main_entry_point.execute_directly(&mut state).unwrap(), expected_call_info);
 }

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/library_call.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/library_call.rs
@@ -103,11 +103,7 @@ fn test_nested_library_call(test_contract: FeatureContract, expected_gas: u64) {
     // Todo(rodrigo): Execution resources from the VM & Native are mesaured differently
     // helper function to change the expected resource values from both of executions
     let if_sierra = |a, b| {
-        if matches!(test_contract, FeatureContract::SierraTestContract) {
-            a
-        } else {
-            b
-        }
+        if matches!(test_contract, FeatureContract::SierraTestContract) { a } else { b }
     };
 
     // Create expected call info tree.

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/mod.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/mod.rs
@@ -28,7 +28,7 @@ fn assert_contract_uses_native(class_hash: ClassHash, state: &dyn State) {
         state
             .get_compiled_contract_class(class_hash)
             .unwrap_or_else(|_| panic!("Expected contract class at {class_hash}")),
-        ContractClass::V1Sierra(_)
+        ContractClass::V1Native(_)
     )
 }
 

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/out_of_gas.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/out_of_gas.rs
@@ -26,6 +26,6 @@ fn test_out_of_gas(test_contract: FeatureContract) {
         initial_gas: REQUIRED_GAS_STORAGE_READ_WRITE_TEST - 1,
         ..trivial_external_entry_point_new(test_contract)
     };
-    let error = entry_point_call.execute_directly(&mut state, None).unwrap_err().to_string();
+    let error = entry_point_call.execute_directly(&mut state).unwrap_err().to_string();
     assert!(error.contains("Out of gas"));
 }

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/replace_class.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/replace_class.rs
@@ -23,7 +23,7 @@ fn undeclared_class_hash(test_contract: FeatureContract) {
         entry_point_selector: selector_from_name("test_replace_class"),
         ..trivial_external_entry_point_new(test_contract)
     };
-    let error = entry_point_call.execute_directly(&mut state, None).unwrap_err().to_string();
+    let error = entry_point_call.execute_directly(&mut state).unwrap_err().to_string();
     assert!(error.contains("is not declared"));
 }
 
@@ -45,7 +45,7 @@ fn cairo0_class_hash(test_contract: FeatureContract) {
         entry_point_selector: selector_from_name("test_replace_class"),
         ..trivial_external_entry_point_new(test_contract)
     };
-    let error = entry_point_call.execute_directly(&mut state, None).unwrap_err().to_string();
+    let error = entry_point_call.execute_directly(&mut state).unwrap_err().to_string();
     assert!(error.contains("Cannot replace V1 class hash with V0 class hash"));
 }
 
@@ -70,7 +70,7 @@ fn positive_flow(test_contract: FeatureContract, gas_consumed: u64) {
         ..trivial_external_entry_point_new(test_contract)
     };
     assert_eq!(
-        entry_point_call.execute_directly(&mut state, None).unwrap().execution,
+        entry_point_call.execute_directly(&mut state).unwrap().execution,
         CallExecution { gas_consumed, ..Default::default() }
     );
     assert_eq!(state.get_class_hash_at(contract_address).unwrap(), new_class_hash);

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/secp.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/secp.rs
@@ -24,7 +24,7 @@ fn test_secp256k1(test_contract: FeatureContract, expected_gas: u64) {
     };
 
     pretty_assertions::assert_eq!(
-        entry_point_call.execute_directly(&mut state, None).unwrap().execution,
+        entry_point_call.execute_directly(&mut state).unwrap().execution,
         CallExecution { gas_consumed: expected_gas, ..Default::default() }
     );
 }
@@ -43,7 +43,7 @@ fn test_secp256r1(test_contract: FeatureContract, expected_gas: u64) {
     };
 
     pretty_assertions::assert_eq!(
-        entry_point_call.execute_directly(&mut state, None).unwrap().execution,
+        entry_point_call.execute_directly(&mut state).unwrap().execution,
         CallExecution { gas_consumed: expected_gas, ..Default::default() }
     );
 }

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/send_message_to_l1.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/send_message_to_l1.rs
@@ -44,7 +44,7 @@ fn test_send_message_to_l1(test_contract: FeatureContract, expected_gas: u64) {
     let message = MessageToL1 { to_address, payload: L2ToL1Payload(payload) };
 
     pretty_assertions::assert_eq!(
-        entry_point_call.execute_directly(&mut state, None).unwrap().execution,
+        entry_point_call.execute_directly(&mut state).unwrap().execution,
         CallExecution {
             l2_to_l1_messages: vec![OrderedL2ToL1Message { order: 0, message }],
             gas_consumed: expected_gas,

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/storage_read_write.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/storage_read_write.rs
@@ -36,7 +36,7 @@ fn test_storage_read_write(test_contract: FeatureContract, expected_gas: u64) {
     };
     let storage_address = entry_point_call.storage_address;
     assert_eq!(
-        entry_point_call.execute_directly(&mut state, None).unwrap().execution,
+        entry_point_call.execute_directly(&mut state).unwrap().execution,
         CallExecution {
             retdata: retdata![stark_felt!(value)],
             gas_consumed: expected_gas,

--- a/crates/blockifier/src/fee/actual_cost_test.rs
+++ b/crates/blockifier/src/fee/actual_cost_test.rs
@@ -298,7 +298,7 @@ fn test_calculate_tx_gas_usage(#[values(false, true)] use_kzg_da: bool) {
     let calldata_length = account_tx.calldata_length();
     let signature_length = account_tx.signature_length();
     let fee_token_address = chain_info.fee_token_address(&account_tx.fee_type());
-    let tx_execution_info = account_tx.execute(state, block_context, true, true, None).unwrap();
+    let tx_execution_info = account_tx.execute(state, block_context, true, true).unwrap();
 
     let n_storage_updates = 1; // For the account balance update.
     let n_modified_contracts = 1;
@@ -347,7 +347,7 @@ fn test_calculate_tx_gas_usage(#[values(false, true)] use_kzg_da: bool) {
 
     let calldata_length = account_tx.calldata_length();
     let signature_length = account_tx.signature_length();
-    let tx_execution_info = account_tx.execute(state, block_context, true, true, None).unwrap();
+    let tx_execution_info = account_tx.execute(state, block_context, true, true).unwrap();
     // For the balance update of the sender and the recipient.
     let n_storage_updates = 2;
     // Only the account contract modification (nonce update) excluding the fee token contract.

--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -522,7 +522,6 @@ pub fn deploy_contract(
         ctor_context,
         wrapper_calldata,
         u64::MAX,
-        None,
     )
     .map_err(|_| vec![Felt::from_hex(FAILED_TO_EXECUTE_CALL).unwrap()])?;
 
@@ -655,7 +654,7 @@ impl TestContext {
         };
 
         let result =
-            entry_point_call.execute_directly(&mut self.state, None).map_err(|e| e.to_string())?;
+            entry_point_call.execute_directly(&mut self.state).map_err(|e| e.to_string())?;
 
         let events = result.execution.events.clone();
 

--- a/crates/blockifier/src/test_utils/cached_state.rs
+++ b/crates/blockifier/src/test_utils/cached_state.rs
@@ -7,7 +7,7 @@ use starknet_api::core::ClassHash;
 use starknet_api::hash::StarkHash;
 
 use super::{ERC20_FULL_CONTRACT_PATH, TEST_EMPTY_CONTRACT_CAIRO1_PATH};
-use crate::execution::contract_class::{ContractClassV1, SierraContractClassV1};
+use crate::execution::contract_class::{ContractClassV1, NativeContractClassV1};
 use crate::state::cached_state::ContractClassMapping;
 use crate::test_utils::{TEST_EMPTY_CONTRACT_CLASS_HASH, TEST_ERC20_FULL_CONTRACT_CLASS_HASH};
 
@@ -15,7 +15,7 @@ pub fn get_erc20_class_hash_mapping() -> ContractClassMapping {
     HashMap::from([
         (
             class_hash!(TEST_ERC20_FULL_CONTRACT_CLASS_HASH),
-            SierraContractClassV1::from_file(ERC20_FULL_CONTRACT_PATH).into(),
+            NativeContractClassV1::from_file(ERC20_FULL_CONTRACT_PATH).into(),
         ),
         (
             class_hash!(TEST_EMPTY_CONTRACT_CLASS_HASH),

--- a/crates/blockifier/src/test_utils/contracts.rs
+++ b/crates/blockifier/src/test_utils/contracts.rs
@@ -4,7 +4,7 @@ use starknet_api::hash::StarkHash;
 use starknet_api::{class_hash, contract_address, patricia_key};
 
 use crate::execution::contract_class::{
-    ContractClass, ContractClassV0, ContractClassV1, SierraContractClassV1,
+    ContractClass, ContractClassV0, ContractClassV1, NativeContractClassV1,
 };
 use crate::test_utils::{get_raw_contract_class, CairoVersion};
 
@@ -178,7 +178,7 @@ impl FeatureContract {
         match self {
             // TODO replace once vm/native is a flag
             Self::SierraTestContract | Self::SierraExecutionInfoV1Contract => {
-                SierraContractClassV1::from_file(&self.get_compiled_path()).into()
+                NativeContractClassV1::from_file(&self.get_compiled_path()).into()
             }
             _ => match self.cairo_version() {
                 CairoVersion::Cairo0 => {

--- a/crates/blockifier/src/test_utils/prices.rs
+++ b/crates/blockifier/src/test_utils/prices.rs
@@ -78,7 +78,6 @@ fn fee_transfer_resources(
                 false,
             )
             .unwrap(),
-            None,
         )
         .unwrap()
         .resources

--- a/crates/blockifier/src/test_utils/struct_impls.rs
+++ b/crates/blockifier/src/test_utils/struct_impls.rs
@@ -12,7 +12,7 @@ use crate::blockifier::block::{BlockInfo, GasPrices};
 use crate::bouncer::{BouncerConfig, BouncerWeights, BuiltinCount};
 use crate::context::{BlockContext, ChainInfo, FeeTokenAddresses, TransactionContext};
 use crate::execution::call_info::{CallExecution, CallInfo, Retdata};
-use crate::execution::contract_class::{ContractClassV0, ContractClassV1, SierraContractClassV1};
+use crate::execution::contract_class::{ContractClassV0, ContractClassV1, NativeContractClassV1};
 use crate::execution::entry_point::{
     CallEntryPoint, EntryPointExecutionContext, EntryPointExecutionResult,
 };
@@ -189,7 +189,7 @@ impl ContractClassV1 {
     }
 }
 
-impl SierraContractClassV1 {
+impl NativeContractClassV1 {
     pub fn from_file(contract_path: &str) -> Self {
         let raw_contract_class = get_raw_contract_class(contract_path);
         Self::try_from_json_string(&raw_contract_class).unwrap()

--- a/crates/blockifier/src/test_utils/struct_impls.rs
+++ b/crates/blockifier/src/test_utils/struct_impls.rs
@@ -1,10 +1,9 @@
 use std::sync::Arc;
 
-use cairo_native::cache::ProgramCache;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use serde_json::Value;
 use starknet_api::block::{BlockNumber, BlockTimestamp};
-use starknet_api::core::{ChainId, ClassHash, ContractAddress, PatriciaKey};
+use starknet_api::core::{ChainId, ContractAddress, PatriciaKey};
 use starknet_api::hash::StarkHash;
 use starknet_api::{contract_address, patricia_key};
 
@@ -32,16 +31,11 @@ use crate::versioned_constants::{
 impl CallEntryPoint {
     /// Executes the call directly, without account context. Limits the number of steps by resource
     /// bounds.
-    pub fn execute_directly(
-        self,
-        state: &mut dyn State,
-        program_cache: Option<&mut ProgramCache<'_, ClassHash>>,
-    ) -> EntryPointExecutionResult<CallInfo> {
+    pub fn execute_directly(self, state: &mut dyn State) -> EntryPointExecutionResult<CallInfo> {
         self.execute_directly_given_tx_info(
             state,
             TransactionInfo::Deprecated(DeprecatedTransactionInfo::default()),
             true,
-            program_cache,
         )
     }
 
@@ -50,14 +44,13 @@ impl CallEntryPoint {
         state: &mut dyn State,
         tx_info: TransactionInfo,
         limit_steps_by_resources: bool,
-        program_cache: Option<&mut ProgramCache<'_, ClassHash>>,
     ) -> EntryPointExecutionResult<CallInfo> {
         let tx_context =
             TransactionContext { block_context: BlockContext::create_for_testing(), tx_info };
         let mut context =
             EntryPointExecutionContext::new_invoke(Arc::new(tx_context), limit_steps_by_resources)
                 .unwrap();
-        self.execute(state, &mut ExecutionResources::default(), &mut context, program_cache)
+        self.execute(state, &mut ExecutionResources::default(), &mut context)
     }
 
     /// Executes the call directly in validate mode, without account context. Limits the number of
@@ -65,13 +58,11 @@ impl CallEntryPoint {
     pub fn execute_directly_in_validate_mode(
         self,
         state: &mut dyn State,
-        program_cache: Option<&mut ProgramCache<'_, ClassHash>>,
     ) -> EntryPointExecutionResult<CallInfo> {
         self.execute_directly_given_tx_info_in_validate_mode(
             state,
             TransactionInfo::Deprecated(DeprecatedTransactionInfo::default()),
             true,
-            program_cache,
         )
     }
 
@@ -80,7 +71,6 @@ impl CallEntryPoint {
         state: &mut dyn State,
         tx_info: TransactionInfo,
         limit_steps_by_resources: bool,
-        program_cache: Option<&mut ProgramCache<'_, ClassHash>>,
     ) -> EntryPointExecutionResult<CallInfo> {
         let tx_context =
             TransactionContext { block_context: BlockContext::create_for_testing(), tx_info };
@@ -89,7 +79,7 @@ impl CallEntryPoint {
             limit_steps_by_resources,
         )
         .unwrap();
-        self.execute(state, &mut ExecutionResources::default(), &mut context, program_cache)
+        self.execute(state, &mut ExecutionResources::default(), &mut context)
     }
 }
 

--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -605,11 +605,7 @@ impl AccountTransaction {
     /// Returns 0 on non-declare transactions; for declare transactions, returns the class code
     /// size.
     pub(crate) fn declare_code_size(&self) -> usize {
-        if let Self::Declare(tx) = self {
-            tx.class_info.code_size()
-        } else {
-            0
-        }
+        if let Self::Declare(tx) = self { tx.class_info.code_size() } else { 0 }
     }
 
     fn is_non_revertible(&self, tx_info: &TransactionInfo) -> bool {

--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -1,9 +1,8 @@
 use std::sync::Arc;
 
-use cairo_native::cache::ProgramCache;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use starknet_api::calldata;
-use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector};
+use starknet_api::core::{ContractAddress, EntryPointSelector};
 use starknet_api::deprecated_contract_class::EntryPointType;
 use starknet_api::hash::StarkFelt;
 use starknet_api::transaction::{Calldata, Fee, ResourceBounds, TransactionVersion};
@@ -266,17 +265,9 @@ impl AccountTransaction {
         remaining_gas: &mut u64,
         validate: bool,
         limit_steps_by_resources: bool,
-        program_cache: Option<&mut ProgramCache<'_, ClassHash>>,
     ) -> TransactionExecutionResult<Option<CallInfo>> {
         if validate {
-            self.validate_tx(
-                state,
-                resources,
-                tx_context,
-                remaining_gas,
-                limit_steps_by_resources,
-                program_cache,
-            )
+            self.validate_tx(state, resources, tx_context, remaining_gas, limit_steps_by_resources)
         } else {
             Ok(None)
         }
@@ -318,7 +309,6 @@ impl AccountTransaction {
         tx_context: Arc<TransactionContext>,
         actual_fee: Fee,
         charge_fee: bool,
-        program_cache: Option<&mut ProgramCache<'_, ClassHash>>,
     ) -> TransactionExecutionResult<Option<CallInfo>> {
         if !charge_fee || actual_fee == Fee(0) {
             // Fee charging is not enforced in some transaction simulations and tests.
@@ -334,7 +324,7 @@ impl AccountTransaction {
         {
             Self::concurrency_execute_fee_transfer(state, tx_context, actual_fee)?
         } else {
-            Self::execute_fee_transfer(state, tx_context, actual_fee, program_cache)?
+            Self::execute_fee_transfer(state, tx_context, actual_fee)?
         };
 
         Ok(Some(fee_transfer_call_info))
@@ -344,7 +334,6 @@ impl AccountTransaction {
         state: &mut dyn State,
         tx_context: Arc<TransactionContext>,
         actual_fee: Fee,
-        program_cache: Option<&mut ProgramCache<'_, ClassHash>>,
     ) -> TransactionExecutionResult<CallInfo> {
         // The least significant 128 bits of the amount transferred.
         let lsb_amount = StarkFelt::from(actual_fee.0);
@@ -373,7 +362,7 @@ impl AccountTransaction {
         let mut context = EntryPointExecutionContext::new_invoke(tx_context, true)?;
 
         Ok(fee_transfer_call
-            .execute(state, &mut ExecutionResources::default(), &mut context, program_cache)
+            .execute(state, &mut ExecutionResources::default(), &mut context)
             .map_err(TransactionFeeError::ExecuteFeeTransferError)?)
     }
 
@@ -403,12 +392,8 @@ impl AccountTransaction {
             cache.set_storage_initial_value(fee_address, key, StarkFelt::ZERO);
         }
 
-        let fee_transfer_call_info = AccountTransaction::execute_fee_transfer(
-            &mut transfer_state,
-            tx_context,
-            actual_fee,
-            None,
-        );
+        let fee_transfer_call_info =
+            AccountTransaction::execute_fee_transfer(&mut transfer_state, tx_context, actual_fee);
         // Commit without updating the sequencer balance.
         let storage_writes = &mut transfer_state.cache.get_mut().writes.storage;
         storage_writes.remove(&(fee_address, sequencer_balance_key_low));
@@ -423,18 +408,11 @@ impl AccountTransaction {
         resources: &mut ExecutionResources,
         context: &mut EntryPointExecutionContext,
         remaining_gas: &mut u64,
-        program_cache: Option<&mut ProgramCache<'_, ClassHash>>,
     ) -> TransactionExecutionResult<Option<CallInfo>> {
         match &self {
-            Self::Declare(tx) => {
-                tx.run_execute(state, resources, context, remaining_gas, program_cache)
-            }
-            Self::DeployAccount(tx) => {
-                tx.run_execute(state, resources, context, remaining_gas, program_cache)
-            }
-            Self::Invoke(tx) => {
-                tx.run_execute(state, resources, context, remaining_gas, program_cache)
-            }
+            Self::Declare(tx) => tx.run_execute(state, resources, context, remaining_gas),
+            Self::DeployAccount(tx) => tx.run_execute(state, resources, context, remaining_gas),
+            Self::Invoke(tx) => tx.run_execute(state, resources, context, remaining_gas),
         }
     }
 
@@ -445,7 +423,6 @@ impl AccountTransaction {
         remaining_gas: &mut u64,
         validate: bool,
         charge_fee: bool,
-        mut program_cache: Option<&mut ProgramCache<'_, ClassHash>>,
     ) -> TransactionExecutionResult<ValidateExecuteCallInfo> {
         println!("AccountTransaction::run_non_revertible");
         let mut resources = ExecutionResources::default();
@@ -458,13 +435,8 @@ impl AccountTransaction {
             // validation context.
             let mut execution_context =
                 EntryPointExecutionContext::new_validate(tx_context.clone(), charge_fee)?;
-            execute_call_info = self.run_execute(
-                state,
-                &mut resources,
-                &mut execution_context,
-                remaining_gas,
-                program_cache.as_deref_mut(),
-            )?;
+            execute_call_info =
+                self.run_execute(state, &mut resources, &mut execution_context, remaining_gas)?;
             validate_call_info = self.handle_validate_tx(
                 state,
                 &mut resources,
@@ -472,7 +444,6 @@ impl AccountTransaction {
                 remaining_gas,
                 validate,
                 charge_fee,
-                program_cache,
             )?;
         } else {
             let mut execution_context =
@@ -484,15 +455,9 @@ impl AccountTransaction {
                 remaining_gas,
                 validate,
                 charge_fee,
-                program_cache.as_deref_mut(),
             )?;
-            execute_call_info = self.run_execute(
-                state,
-                &mut resources,
-                &mut execution_context,
-                remaining_gas,
-                program_cache,
-            )?;
+            execute_call_info =
+                self.run_execute(state, &mut resources, &mut execution_context, remaining_gas)?;
         }
 
         let tx_receipt = TransactionReceipt::from_account_tx(
@@ -523,7 +488,6 @@ impl AccountTransaction {
         remaining_gas: &mut u64,
         validate: bool,
         charge_fee: bool,
-        mut program_cache: Option<&mut ProgramCache<'_, ClassHash>>,
     ) -> TransactionExecutionResult<ValidateExecuteCallInfo> {
         let mut resources = ExecutionResources::default();
         let mut execution_context =
@@ -536,7 +500,6 @@ impl AccountTransaction {
             remaining_gas,
             validate,
             charge_fee,
-            program_cache.as_deref_mut(),
         )?;
 
         let n_allotted_execution_steps = execution_context.subtract_validation_and_overhead_steps(
@@ -559,7 +522,6 @@ impl AccountTransaction {
             &mut execution_resources,
             &mut execution_context,
             remaining_gas,
-            program_cache,
         );
 
         // Pre-compute cost in case of revert.
@@ -643,7 +605,11 @@ impl AccountTransaction {
     /// Returns 0 on non-declare transactions; for declare transactions, returns the class code
     /// size.
     pub(crate) fn declare_code_size(&self) -> usize {
-        if let Self::Declare(tx) = self { tx.class_info.code_size() } else { 0 }
+        if let Self::Declare(tx) = self {
+            tx.class_info.code_size()
+        } else {
+            0
+        }
     }
 
     fn is_non_revertible(&self, tx_info: &TransactionInfo) -> bool {
@@ -667,20 +633,12 @@ impl AccountTransaction {
         tx_context: Arc<TransactionContext>,
         validate: bool,
         charge_fee: bool,
-        program_cache: Option<&mut ProgramCache<'_, ClassHash>>,
     ) -> TransactionExecutionResult<ValidateExecuteCallInfo> {
         if self.is_non_revertible(&tx_context.tx_info) {
-            return self.run_non_revertible(
-                state,
-                tx_context,
-                remaining_gas,
-                validate,
-                charge_fee,
-                program_cache,
-            );
+            return self.run_non_revertible(state, tx_context, remaining_gas, validate, charge_fee);
         }
 
-        self.run_revertible(state, tx_context, remaining_gas, validate, charge_fee, program_cache)
+        self.run_revertible(state, tx_context, remaining_gas, validate, charge_fee)
     }
 }
 
@@ -691,7 +649,6 @@ impl<S: StateReader> ExecutableTransaction<S> for AccountTransaction {
         block_context: &BlockContext,
         charge_fee: bool,
         validate: bool,
-        mut program_cache: Option<&mut ProgramCache<'_, ClassHash>>,
     ) -> TransactionExecutionResult<TransactionExecutionInfo> {
         let tx_context = Arc::new(block_context.to_tx_context(self));
         self.verify_tx_version(tx_context.tx_info.version())?;
@@ -719,10 +676,8 @@ impl<S: StateReader> ExecutableTransaction<S> for AccountTransaction {
             tx_context.clone(),
             validate,
             charge_fee,
-            program_cache.as_deref_mut(),
         )?;
-        let fee_transfer_call_info =
-            self.handle_fee(state, tx_context, final_fee, charge_fee, program_cache)?;
+        let fee_transfer_call_info = self.handle_fee(state, tx_context, final_fee, charge_fee)?;
 
         let tx_execution_info = TransactionExecutionInfo {
             validate_call_info,
@@ -786,7 +741,6 @@ impl ValidatableTransaction for AccountTransaction {
         tx_context: Arc<TransactionContext>,
         remaining_gas: &mut u64,
         limit_steps_by_resources: bool,
-        program_cache: Option<&mut ProgramCache<'_, ClassHash>>,
     ) -> TransactionExecutionResult<Option<CallInfo>> {
         let mut context =
             EntryPointExecutionContext::new_validate(tx_context, limit_steps_by_resources)?;
@@ -810,13 +764,14 @@ impl ValidatableTransaction for AccountTransaction {
             initial_gas: *remaining_gas,
         };
 
-        let validate_call_info = validate_call
-            .execute(state, resources, &mut context, program_cache)
-            .map_err(|error| TransactionExecutionError::ValidateTransactionError {
-                error,
-                class_hash,
-                storage_address,
-                selector: validate_selector,
+        let validate_call_info =
+            validate_call.execute(state, resources, &mut context).map_err(|error| {
+                TransactionExecutionError::ValidateTransactionError {
+                    error,
+                    class_hash,
+                    storage_address,
+                    selector: validate_selector,
+                }
             })?;
 
         // Validate return data.

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -73,7 +73,7 @@ fn test_fee_enforcement(
 
     let account_tx = AccountTransaction::DeployAccount(deploy_account_tx);
     let enforce_fee = account_tx.create_tx_info().enforce_fee().unwrap();
-    let result = account_tx.execute(state, &block_context, true, true, None);
+    let result = account_tx.execute(state, &block_context, true, true);
     assert_eq!(result.is_err(), enforce_fee);
 }
 
@@ -222,12 +222,10 @@ fn test_infinite_recursion(
     if success {
         assert!(tx_execution_info.revert_error.is_none());
     } else {
-        assert!(
-            tx_execution_info
-                .revert_error
-                .unwrap()
-                .contains("RunResources has no remaining steps.")
-        );
+        assert!(tx_execution_info
+            .revert_error
+            .unwrap()
+            .contains("RunResources has no remaining steps."));
     }
 }
 
@@ -260,7 +258,7 @@ fn test_max_fee_limit_validate(
         },
         class_info,
     );
-    account_tx.execute(&mut state, &block_context, true, true, None).unwrap();
+    account_tx.execute(&mut state, &block_context, true, true).unwrap();
 
     // Deploy grindy account with a lot of grind in the constructor.
     // Expect this to fail without bumping nonce, so pass a temporary nonce manager.
@@ -276,10 +274,8 @@ fn test_max_fee_limit_validate(
             constructor_calldata: calldata![ctor_grind_arg, ctor_storage_arg],
         },
     );
-    let error_trace = deploy_account_tx
-        .execute(&mut state, &block_context, true, true, None)
-        .unwrap_err()
-        .to_string();
+    let error_trace =
+        deploy_account_tx.execute(&mut state, &block_context, true, true).unwrap_err().to_string();
     assert!(error_trace.contains("no remaining steps"));
 
     // Deploy grindy account successfully this time.
@@ -294,7 +290,7 @@ fn test_max_fee_limit_validate(
             constructor_calldata: calldata![ctor_grind_arg, ctor_storage_arg],
         },
     );
-    deploy_account_tx.execute(&mut state, &block_context, true, true, None).unwrap();
+    deploy_account_tx.execute(&mut state, &block_context, true, true).unwrap();
 
     // Invoke a function that grinds validate (any function will do); set bounds low enough to fail
     // on this grind.
@@ -533,7 +529,7 @@ An ASSERT_EQ instruction failed: 1 != 0.
     };
 
     // Compare expected and actual error.
-    let error = deploy_account_tx.execute(state, &block_context, true, true, None).unwrap_err();
+    let error = deploy_account_tx.execute(state, &block_context, true, true).unwrap_err();
     assert_eq!(error.to_string(), expected_error);
 }
 
@@ -570,7 +566,7 @@ fn test_fail_deploy_account(
 
     let initial_balance = state.get_fee_token_balance(deploy_address, fee_token_address).unwrap();
 
-    let error = deploy_account_tx.execute(state, &block_context, true, true, None).unwrap_err();
+    let error = deploy_account_tx.execute(state, &block_context, true, true).unwrap_err();
     // Check the error is as expected. Assure the error message is not nonce or fee related.
     check_transaction_execution_error_for_invalid_scenario!(cairo_version, error, false);
 
@@ -620,7 +616,7 @@ fn test_fail_declare(block_context: BlockContext, max_fee: Fee) {
     let initial_balance = state
         .get_fee_token_balance(account_address, chain_info.fee_token_address(&tx_info.fee_type()))
         .unwrap();
-    declare_account_tx.execute(&mut state, &block_context, true, true, None).unwrap_err();
+    declare_account_tx.execute(&mut state, &block_context, true, true).unwrap_err();
 
     assert_eq!(state.get_nonce_at(account_address).unwrap(), next_nonce);
     assert_eq!(
@@ -897,8 +893,7 @@ fn test_max_fee_to_max_steps_conversion(
     let tx_context1 = Arc::new(block_context.to_tx_context(&account_tx1));
     let execution_context1 = EntryPointExecutionContext::new_invoke(tx_context1, true).unwrap();
     let max_steps_limit1 = execution_context1.vm_run_resources.get_n_steps();
-    let tx_execution_info1 =
-        account_tx1.execute(&mut state, &block_context, true, true, None).unwrap();
+    let tx_execution_info1 = account_tx1.execute(&mut state, &block_context, true, true).unwrap();
     let n_steps1 = tx_execution_info1.actual_resources.vm_resources.n_steps;
     let gas_used_vector1 = tx_execution_info1
         .actual_resources
@@ -917,8 +912,7 @@ fn test_max_fee_to_max_steps_conversion(
     let tx_context2 = Arc::new(block_context.to_tx_context(&account_tx2));
     let execution_context2 = EntryPointExecutionContext::new_invoke(tx_context2, true).unwrap();
     let max_steps_limit2 = execution_context2.vm_run_resources.get_n_steps();
-    let tx_execution_info2 =
-        account_tx2.execute(&mut state, &block_context, true, true, None).unwrap();
+    let tx_execution_info2 = account_tx2.execute(&mut state, &block_context, true, true).unwrap();
     let n_steps2 = tx_execution_info2.actual_resources.vm_resources.n_steps;
     let gas_used_vector2 = tx_execution_info2
         .actual_resources
@@ -1002,9 +996,10 @@ fn test_insufficient_max_fee_reverts(
     .unwrap();
     assert!(tx_execution_info3.is_reverted());
     assert!(tx_execution_info3.actual_fee == actual_fee_depth1);
-    assert!(
-        tx_execution_info3.revert_error.unwrap().contains("RunResources has no remaining steps.")
-    );
+    assert!(tx_execution_info3
+        .revert_error
+        .unwrap()
+        .contains("RunResources has no remaining steps."));
 }
 
 #[rstest]
@@ -1031,7 +1026,7 @@ fn test_deploy_account_constructor_storage_write(
             constructor_calldata: constructor_calldata.clone(),
         },
     );
-    deploy_account_tx.execute(state, &block_context, true, true, None).unwrap();
+    deploy_account_tx.execute(state, &block_context, true, true).unwrap();
 
     // Check that the constructor wrote ctor_arg to the storage.
     let storage_key = get_storage_var_address("ctor_arg", &[]);
@@ -1102,8 +1097,7 @@ fn test_count_actual_storage_changes(
         nonce: nonce_manager.next(account_address),
     };
     let account_tx = account_invoke_tx(invoke_args.clone());
-    let execution_info =
-        account_tx.execute_raw(&mut state, &block_context, true, true, None).unwrap();
+    let execution_info = account_tx.execute_raw(&mut state, &block_context, true, true).unwrap();
 
     let fee_1 = execution_info.actual_fee;
     let state_changes_1 = state.get_actual_state_changes().unwrap();
@@ -1147,8 +1141,7 @@ fn test_count_actual_storage_changes(
         nonce: nonce_manager.next(account_address),
         ..invoke_args.clone()
     });
-    let execution_info =
-        account_tx.execute_raw(&mut state, &block_context, true, true, None).unwrap();
+    let execution_info = account_tx.execute_raw(&mut state, &block_context, true, true).unwrap();
 
     let fee_2 = execution_info.actual_fee;
     let state_changes_2 = state.get_actual_state_changes().unwrap();
@@ -1185,8 +1178,7 @@ fn test_count_actual_storage_changes(
         calldata: transfer_calldata,
         ..invoke_args
     });
-    let execution_info =
-        account_tx.execute_raw(&mut state, &block_context, true, true, None).unwrap();
+    let execution_info = account_tx.execute_raw(&mut state, &block_context, true, true).unwrap();
 
     let fee_transfer = execution_info.actual_fee;
     let state_changes_transfer = state.get_actual_state_changes().unwrap();
@@ -1259,7 +1251,7 @@ fn test_concurrency_execute_fee_transfer(#[values(FeeType::Eth, FeeType::Strk)] 
     // Case 1: The transaction did not read form/ write to the sequenser balance before executing
     // fee transfer.
     let mut transactional_state = CachedState::create_transactional(state);
-    account_tx.execute_raw(&mut transactional_state, &block_context, true, false, None).unwrap();
+    account_tx.execute_raw(&mut transactional_state, &block_context, true, false).unwrap();
     let transactional_cache = transactional_state.cache.borrow();
     for storage in [
         transactional_cache.initial_reads.storage.clone(),
@@ -1287,7 +1279,7 @@ fn test_concurrency_execute_fee_transfer(#[values(FeeType::Eth, FeeType::Strk)] 
         transactional_state.set_storage_at(fee_token_address, seq_key, stark_felt!(value)).unwrap();
     }
 
-    account_tx.execute_raw(&mut transactional_state, &block_context, true, false, None).unwrap();
+    account_tx.execute_raw(&mut transactional_state, &block_context, true, false).unwrap();
     // Check that the sequencer balance was not changed.
     let storage_write = transactional_state.cache.borrow().writes.storage.clone();
     let storage_initial_values = transactional_state.cache.borrow().initial_reads.storage.clone();

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -222,10 +222,12 @@ fn test_infinite_recursion(
     if success {
         assert!(tx_execution_info.revert_error.is_none());
     } else {
-        assert!(tx_execution_info
-            .revert_error
-            .unwrap()
-            .contains("RunResources has no remaining steps."));
+        assert!(
+            tx_execution_info
+                .revert_error
+                .unwrap()
+                .contains("RunResources has no remaining steps.")
+        );
     }
 }
 
@@ -996,10 +998,9 @@ fn test_insufficient_max_fee_reverts(
     .unwrap();
     assert!(tx_execution_info3.is_reverted());
     assert!(tx_execution_info3.actual_fee == actual_fee_depth1);
-    assert!(tx_execution_info3
-        .revert_error
-        .unwrap()
-        .contains("RunResources has no remaining steps."));
+    assert!(
+        tx_execution_info3.revert_error.unwrap().contains("RunResources has no remaining steps.")
+    );
 }
 
 #[rstest]

--- a/crates/blockifier/src/transaction/execution_flavors_test.rs
+++ b/crates/blockifier/src/transaction/execution_flavors_test.rs
@@ -178,7 +178,7 @@ fn test_simulate_validate_charge_fee_pre_validate(
     let result = account_invoke_tx(
         invoke_tx_args! {nonce: invalid_nonce, ..pre_validation_base_args.clone()},
     )
-    .execute(&mut state, &block_context, charge_fee, validate, None);
+    .execute(&mut state, &block_context, charge_fee, validate);
     assert_matches!(
         result.unwrap_err(),
         TransactionExecutionError::TransactionPreValidationError(
@@ -206,7 +206,7 @@ fn test_simulate_validate_charge_fee_pre_validate(
         nonce: nonce_manager.next(account_address),
         ..pre_validation_base_args.clone()
     })
-    .execute(&mut state, &block_context, charge_fee, validate, None);
+    .execute(&mut state, &block_context, charge_fee, validate);
     if !charge_fee {
         check_gas_and_fee(
             &block_context,
@@ -250,7 +250,7 @@ fn test_simulate_validate_charge_fee_pre_validate(
         nonce: nonce_manager.next(account_address),
         ..pre_validation_base_args.clone()
     })
-    .execute(&mut state, &block_context, charge_fee, validate, None);
+    .execute(&mut state, &block_context, charge_fee, validate);
     if !charge_fee {
         check_gas_and_fee(
             &block_context,
@@ -290,7 +290,7 @@ fn test_simulate_validate_charge_fee_pre_validate(
             nonce: nonce_manager.next(account_address),
             ..pre_validation_base_args
         })
-        .execute(&mut state, &block_context, charge_fee, validate, None);
+        .execute(&mut state, &block_context, charge_fee, validate);
         if !charge_fee {
             check_gas_and_fee(
                 &block_context,
@@ -357,7 +357,7 @@ fn test_simulate_validate_charge_fee_fail_validate(
         nonce: nonce_manager.next(faulty_account_address),
         only_query,
     })
-    .execute(&mut falliable_state, &block_context, charge_fee, validate, None);
+    .execute(&mut falliable_state, &block_context, charge_fee, validate);
     if !validate {
         // The reported fee should be the actual cost, regardless of whether or not fee is charged.
         check_gas_and_fee(
@@ -369,9 +369,10 @@ fn test_simulate_validate_charge_fee_fail_validate(
             actual_fee,
         );
     } else {
-        assert!(
-            result.unwrap_err().to_string().contains("An ASSERT_EQ instruction failed: 1 != 0.")
-        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("An ASSERT_EQ instruction failed: 1 != 0."));
     }
 }
 
@@ -427,7 +428,7 @@ fn test_simulate_validate_charge_fee_mid_execution(
         nonce: nonce_manager.next(account_address),
         ..execution_base_args.clone()
     })
-    .execute(&mut state, &block_context, charge_fee, validate, None)
+    .execute(&mut state, &block_context, charge_fee, validate)
     .unwrap();
     assert!(tx_execution_info.is_reverted());
     check_gas_and_fee(
@@ -469,7 +470,7 @@ fn test_simulate_validate_charge_fee_mid_execution(
         nonce: nonce_manager.next(account_address),
         ..execution_base_args.clone()
     })
-    .execute(&mut state, &block_context, charge_fee, validate, None)
+    .execute(&mut state, &block_context, charge_fee, validate)
     .unwrap();
     assert_eq!(tx_execution_info.is_reverted(), charge_fee);
     if charge_fee {
@@ -521,7 +522,7 @@ fn test_simulate_validate_charge_fee_mid_execution(
         nonce: nonce_manager.next(account_address),
         ..execution_base_args
     })
-    .execute(&mut state, &low_step_block_context, charge_fee, validate, None)
+    .execute(&mut state, &low_step_block_context, charge_fee, validate)
     .unwrap();
     assert!(tx_execution_info.revert_error.clone().unwrap().contains("no remaining steps"));
     // Complete resources used are reported as actual_resources; but only the charged final fee is
@@ -604,7 +605,7 @@ fn test_simulate_validate_charge_fee_post_execution(
         version,
         only_query,
     })
-    .execute(&mut state, &block_context, charge_fee, validate, None)
+    .execute(&mut state, &block_context, charge_fee, validate)
     .unwrap();
     assert_eq!(tx_execution_info.is_reverted(), charge_fee);
     if charge_fee {
@@ -669,17 +670,15 @@ fn test_simulate_validate_charge_fee_post_execution(
         version,
         only_query,
     })
-    .execute(&mut state, &block_context, charge_fee, validate, None)
+    .execute(&mut state, &block_context, charge_fee, validate)
     .unwrap();
     assert_eq!(tx_execution_info.is_reverted(), charge_fee);
     if charge_fee {
-        assert!(
-            tx_execution_info
-                .revert_error
-                .clone()
-                .unwrap()
-                .contains("Insufficient fee token balance.")
-        );
+        assert!(tx_execution_info
+            .revert_error
+            .clone()
+            .unwrap()
+            .contains("Insufficient fee token balance."));
     }
     check_gas_and_fee(
         &block_context,

--- a/crates/blockifier/src/transaction/execution_flavors_test.rs
+++ b/crates/blockifier/src/transaction/execution_flavors_test.rs
@@ -369,10 +369,9 @@ fn test_simulate_validate_charge_fee_fail_validate(
             actual_fee,
         );
     } else {
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("An ASSERT_EQ instruction failed: 1 != 0."));
+        assert!(
+            result.unwrap_err().to_string().contains("An ASSERT_EQ instruction failed: 1 != 0.")
+        );
     }
 }
 
@@ -674,11 +673,13 @@ fn test_simulate_validate_charge_fee_post_execution(
     .unwrap();
     assert_eq!(tx_execution_info.is_reverted(), charge_fee);
     if charge_fee {
-        assert!(tx_execution_info
-            .revert_error
-            .clone()
-            .unwrap()
-            .contains("Insufficient fee token balance."));
+        assert!(
+            tx_execution_info
+                .revert_error
+                .clone()
+                .unwrap()
+                .contains("Insufficient fee token balance.")
+        );
     }
     check_gas_and_fee(
         &block_context,

--- a/crates/blockifier/src/transaction/post_execution_test.rs
+++ b/crates/blockifier/src/transaction/post_execution_test.rs
@@ -109,7 +109,7 @@ fn test_revert_on_overdraft(
     });
     let tx_info = approve_tx.create_tx_info();
     let approval_execution_info =
-        approve_tx.execute(&mut state, &block_context, true, true, None).unwrap();
+        approve_tx.execute(&mut state, &block_context, true, true).unwrap();
     assert!(!approval_execution_info.is_reverted());
 
     // Transfer a valid amount of funds to compute the cost of a successful
@@ -296,9 +296,11 @@ fn test_revert_on_resource_overuse(
 
     // Assert the transaction was reverted with the correct error.
     if is_revertible {
-        assert!(
-            execution_info_result.unwrap().revert_error.unwrap().starts_with(expected_error_prefix)
-        );
+        assert!(execution_info_result
+            .unwrap()
+            .revert_error
+            .unwrap()
+            .starts_with(expected_error_prefix));
     } else {
         assert_matches!(
             execution_info_result.unwrap_err(),

--- a/crates/blockifier/src/transaction/post_execution_test.rs
+++ b/crates/blockifier/src/transaction/post_execution_test.rs
@@ -296,11 +296,9 @@ fn test_revert_on_resource_overuse(
 
     // Assert the transaction was reverted with the correct error.
     if is_revertible {
-        assert!(execution_info_result
-            .unwrap()
-            .revert_error
-            .unwrap()
-            .starts_with(expected_error_prefix));
+        assert!(
+            execution_info_result.unwrap().revert_error.unwrap().starts_with(expected_error_prefix)
+        );
     } else {
         assert_matches!(
             execution_info_result.unwrap_err(),

--- a/crates/blockifier/src/transaction/test_utils.rs
+++ b/crates/blockifier/src/transaction/test_utils.rs
@@ -258,7 +258,7 @@ pub fn run_invoke_tx(
     block_context: &BlockContext,
     invoke_args: InvokeTxArgs,
 ) -> TransactionExecutionResult<TransactionExecutionInfo> {
-    account_invoke_tx(invoke_args).execute(state, block_context, true, true, None)
+    account_invoke_tx(invoke_args).execute(state, block_context, true, true)
 }
 
 /// Creates a `ResourceBoundsMapping` with the given `max_amount` and `max_price` for L1 gas limits.

--- a/crates/blockifier/src/transaction/test_utils.rs
+++ b/crates/blockifier/src/transaction/test_utils.rs
@@ -275,7 +275,7 @@ pub fn calculate_class_info_for_testing(contract_class: ContractClass) -> ClassI
     let sierra_program_length = match contract_class {
         ContractClass::V0(_) => 0,
         ContractClass::V1(_) => 100,
-        ContractClass::V1Sierra(_) => todo!("should this also be 100?"),
+        ContractClass::V1Native(_) => todo!("should this also be 100?"),
     };
     ClassInfo::new(&contract_class, sierra_program_length, 100).unwrap()
 }

--- a/crates/blockifier/src/transaction/transaction_execution.rs
+++ b/crates/blockifier/src/transaction/transaction_execution.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 
-use cairo_native::cache::ProgramCache;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
-use starknet_api::core::{calculate_contract_address, ClassHash, ContractAddress};
+use starknet_api::core::{calculate_contract_address, ContractAddress};
 use starknet_api::transaction::{Fee, Transaction as StarknetApiTransaction, TransactionHash};
 
 use crate::context::BlockContext;
@@ -107,20 +106,14 @@ impl<S: StateReader> ExecutableTransaction<S> for L1HandlerTransaction {
         block_context: &BlockContext,
         _charge_fee: bool,
         _validate: bool,
-        program_cache: Option<&mut ProgramCache<'_, ClassHash>>,
     ) -> TransactionExecutionResult<TransactionExecutionInfo> {
         let tx_context = Arc::new(block_context.to_tx_context(self));
 
         let mut execution_resources = ExecutionResources::default();
         let mut context = EntryPointExecutionContext::new_invoke(tx_context.clone(), true)?;
         let mut remaining_gas = block_context.versioned_constants.tx_initial_gas();
-        let execute_call_info = self.run_execute(
-            state,
-            &mut execution_resources,
-            &mut context,
-            &mut remaining_gas,
-            program_cache,
-        )?;
+        let execute_call_info =
+            self.run_execute(state, &mut execution_resources, &mut context, &mut remaining_gas)?;
         let l1_handler_payload_size = self.payload_size();
 
         let TransactionReceipt { fee: actual_fee, da_gas, resources: actual_resources, .. } =
@@ -158,14 +151,13 @@ impl<S: StateReader> ExecutableTransaction<S> for Transaction {
         block_context: &BlockContext,
         charge_fee: bool,
         validate: bool,
-        program_cache: Option<&mut ProgramCache<'_, ClassHash>>,
     ) -> TransactionExecutionResult<TransactionExecutionInfo> {
         match self {
             Self::AccountTransaction(account_tx) => {
-                account_tx.execute_raw(state, block_context, charge_fee, validate, program_cache)
+                account_tx.execute_raw(state, block_context, charge_fee, validate)
             }
             Self::L1HandlerTransaction(tx) => {
-                tx.execute_raw(state, block_context, charge_fee, validate, program_cache)
+                tx.execute_raw(state, block_context, charge_fee, validate)
             }
         }
     }

--- a/crates/blockifier/src/transaction/transaction_utils.rs
+++ b/crates/blockifier/src/transaction/transaction_utils.rs
@@ -31,6 +31,6 @@ pub fn verify_contract_class_version(
                 cairo_version: 1,
             })
         }
-        ContractClass::V1Sierra(_) => todo!("Sierra verify contract class version"),
+        ContractClass::V1Native(_) => todo!("Sierra verify contract class version"),
     }
 }

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -117,11 +117,7 @@ fn expected_validate_call_info(
             usize::from(entry_point_selector_name == constants::VALIDATE_ENTRY_POINT_NAME)
         }
         CairoVersion::Cairo1 => {
-            if entry_point_selector_name == constants::VALIDATE_ENTRY_POINT_NAME {
-                7
-            } else {
-                2
-            }
+            if entry_point_selector_name == constants::VALIDATE_ENTRY_POINT_NAME { 7 } else { 2 }
         }
     };
     let n_steps = match (entry_point_selector_name, cairo_version) {
@@ -1864,10 +1860,12 @@ fn test_execute_tx_with_invalid_transaction_version(block_context: BlockContext)
     });
 
     let execution_info = account_tx.execute(state, block_context, true, true).unwrap();
-    assert!(execution_info
-        .revert_error
-        .unwrap()
-        .contains(format!("ASSERT_EQ instruction failed: {} != 1.", invalid_version).as_str()));
+    assert!(
+        execution_info
+            .revert_error
+            .unwrap()
+            .contains(format!("ASSERT_EQ instruction failed: {} != 1.", invalid_version).as_str())
+    );
 }
 
 fn max_n_emitted_events() -> usize {
@@ -1930,17 +1928,17 @@ fn test_emit_event_exceeds_limit(
     );
 
     let calldata = [
-        vec![
-            stark_felt!(u16::try_from(n_emitted_events).expect("Failed to convert usize to u16.")),
-        ]
+        vec![stark_felt!(
+            u16::try_from(n_emitted_events).expect("Failed to convert usize to u16.")
+        )]
         .to_owned(),
-        vec![
-            stark_felt!(u16::try_from(event_keys.len()).expect("Failed to convert usize to u16.")),
-        ],
+        vec![stark_felt!(
+            u16::try_from(event_keys.len()).expect("Failed to convert usize to u16.")
+        )],
         event_keys.clone(),
-        vec![
-            stark_felt!(u16::try_from(event_data.len()).expect("Failed to convert usize to u16.")),
-        ],
+        vec![stark_felt!(
+            u16::try_from(event_data.len()).expect("Failed to convert usize to u16.")
+        )],
         event_data.clone(),
     ]
     .concat();

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -117,7 +117,11 @@ fn expected_validate_call_info(
             usize::from(entry_point_selector_name == constants::VALIDATE_ENTRY_POINT_NAME)
         }
         CairoVersion::Cairo1 => {
-            if entry_point_selector_name == constants::VALIDATE_ENTRY_POINT_NAME { 7 } else { 2 }
+            if entry_point_selector_name == constants::VALIDATE_ENTRY_POINT_NAME {
+                7
+            } else {
+                2
+            }
         }
     };
     let n_steps = match (entry_point_selector_name, cairo_version) {
@@ -383,7 +387,7 @@ fn test_invoke_tx(
     let account_tx = AccountTransaction::Invoke(invoke_tx);
     let tx_context = block_context.to_tx_context(&account_tx);
 
-    let actual_execution_info = account_tx.execute(state, block_context, true, true, None).unwrap();
+    let actual_execution_info = account_tx.execute(state, block_context, true, true).unwrap();
 
     // Build expected validate call info.
     let expected_account_class_hash = account_contract.get_class_hash();
@@ -554,7 +558,7 @@ fn test_invoke_tx_advanced_operations(
             create_calldata(contract_address, "advance_counter", &calldata_args),
         ..base_tx_args.clone()
     });
-    account_tx.execute(state, block_context, true, true, None).unwrap();
+    account_tx.execute(state, block_context, true, true).unwrap();
 
     let next_nonce = nonce_manager.next(account_address);
     let initial_ec_point = [StarkFelt::ZERO, StarkFelt::ZERO];
@@ -583,7 +587,7 @@ fn test_invoke_tx_advanced_operations(
             create_calldata(contract_address, "call_xor_counters", &calldata_args),
         ..base_tx_args.clone()
     });
-    account_tx.execute(state, block_context, true, true, None).unwrap();
+    account_tx.execute(state, block_context, true, true).unwrap();
 
     let expected_counters = [
         stark_felt!(counter_diffs[0] ^ xor_values[0]),
@@ -607,7 +611,7 @@ fn test_invoke_tx_advanced_operations(
             create_calldata(contract_address, "test_ec_op", &[]),
         ..base_tx_args.clone()
     });
-    account_tx.execute(state, block_context, true, true, None).unwrap();
+    account_tx.execute(state, block_context, true, true).unwrap();
 
     let expected_ec_point = [
         StarkFelt::new([
@@ -645,7 +649,7 @@ fn test_invoke_tx_advanced_operations(
             create_calldata(contract_address, "add_signature_to_counters", &[index]),
         ..base_tx_args.clone()
     });
-    account_tx.execute(state, block_context, true, true, None).unwrap();
+    account_tx.execute(state, block_context, true, true).unwrap();
 
     let expected_counters = [
         felt_to_stark_felt(
@@ -674,7 +678,7 @@ fn test_invoke_tx_advanced_operations(
             create_calldata(contract_address, "send_message", &[felt_to_stark_felt(&to_address)]),
         ..base_tx_args
     });
-    let execution_info = account_tx.execute(state, block_context, true, true, None).unwrap();
+    let execution_info = account_tx.execute(state, block_context, true, true).unwrap();
     let next_nonce = nonce_manager.next(account_address);
     verify_storage_after_invoke_advanced_operations(
         state,
@@ -736,7 +740,7 @@ fn test_state_get_fee_token_balance(
         version: tx_version,
         nonce: Nonce::default(),
     });
-    account_tx.execute(state, block_context, true, true, None).unwrap();
+    account_tx.execute(state, block_context, true, true).unwrap();
 
     // Get balance from state, and validate.
     let (low, high) =
@@ -754,7 +758,7 @@ fn assert_failure_if_resource_bounds_exceed_balance(
     match block_context.to_tx_context(&invalid_tx).tx_info {
         TransactionInfo::Deprecated(context) => {
             assert_matches!(
-                invalid_tx.execute(state, block_context, true, true, None).unwrap_err(),
+                invalid_tx.execute(state, block_context, true, true,).unwrap_err(),
                 TransactionExecutionError::TransactionPreValidationError(
                     TransactionPreValidationError::TransactionFeeError(
                         TransactionFeeError::MaxFeeExceedsBalance{ max_fee, .. }))
@@ -764,7 +768,7 @@ fn assert_failure_if_resource_bounds_exceed_balance(
         TransactionInfo::Current(context) => {
             let l1_bounds = context.l1_resource_bounds().unwrap();
             assert_matches!(
-                invalid_tx.execute(state, block_context, true, true, None).unwrap_err(),
+                invalid_tx.execute(state, block_context, true, true,).unwrap_err(),
                 TransactionExecutionError::TransactionPreValidationError(
                     TransactionPreValidationError::TransactionFeeError(
                         TransactionFeeError::L1GasBoundsExceedBalance{ max_amount, max_price, .. }))
@@ -873,8 +877,7 @@ fn test_insufficient_resource_bounds(
     let invalid_v1_tx = account_invoke_tx(
         invoke_tx_args! { max_fee: invalid_max_fee, ..valid_invoke_tx_args.clone() },
     );
-    let execution_error =
-        invalid_v1_tx.execute(state, block_context, true, true, None).unwrap_err();
+    let execution_error = invalid_v1_tx.execute(state, block_context, true, true).unwrap_err();
 
     // Test error.
     assert_matches!(
@@ -897,8 +900,7 @@ fn test_insufficient_resource_bounds(
         version: TransactionVersion::THREE,
         ..valid_invoke_tx_args.clone()
     });
-    let execution_error =
-        invalid_v3_tx.execute(state, block_context, true, true, None).unwrap_err();
+    let execution_error = invalid_v3_tx.execute(state, block_context, true, true).unwrap_err();
     // TODO(Ori, 1/2/2024): Write an indicative expect message explaining why the conversion works.
     let minimal_l1_gas_as_u64 =
         u64::try_from(minimal_l1_gas).expect("Failed to convert u128 to u64.");
@@ -921,8 +923,7 @@ fn test_insufficient_resource_bounds(
         version: TransactionVersion::THREE,
         ..valid_invoke_tx_args
     });
-    let execution_error =
-        invalid_v3_tx.execute(state, block_context, true, true, None).unwrap_err();
+    let execution_error = invalid_v3_tx.execute(state, block_context, true, true).unwrap_err();
     assert_matches!(
         execution_error,
         TransactionExecutionError::TransactionPreValidationError(
@@ -959,7 +960,7 @@ fn test_actual_fee_gt_resource_bounds(
     // The estimated minimal fee is lower than the actual fee.
     let invalid_tx = account_invoke_tx(invoke_tx_args! { max_fee: minimal_fee, ..invoke_tx_args });
 
-    let execution_result = invalid_tx.execute(state, block_context, true, true, None).unwrap();
+    let execution_result = invalid_tx.execute(state, block_context, true, true).unwrap();
     let execution_error = execution_result.revert_error.unwrap();
     // Test error.
     assert!(execution_error.starts_with("Insufficient max fee:"));
@@ -1127,7 +1128,7 @@ fn test_declare_tx(
     );
     let fee_type = &account_tx.fee_type();
     let tx_context = &block_context.to_tx_context(&account_tx);
-    let actual_execution_info = account_tx.execute(state, block_context, true, true, None).unwrap();
+    let actual_execution_info = account_tx.execute(state, block_context, true, true).unwrap();
 
     // Build expected validate call info.
     let expected_validate_call_info = declare_validate_callinfo(
@@ -1242,7 +1243,7 @@ fn test_deploy_account_tx(
     let account_tx = AccountTransaction::DeployAccount(deploy_account);
     let fee_type = &account_tx.fee_type();
     let tx_context = &block_context.to_tx_context(&account_tx);
-    let actual_execution_info = account_tx.execute(state, block_context, true, true, None).unwrap();
+    let actual_execution_info = account_tx.execute(state, block_context, true, true).unwrap();
 
     // Build expected validate call info.
     let validate_calldata =
@@ -1348,7 +1349,7 @@ fn test_deploy_account_tx(
         &mut nonce_manager,
     );
     let account_tx = AccountTransaction::DeployAccount(deploy_account);
-    let error = account_tx.execute(state, block_context, true, true, None).unwrap_err();
+    let error = account_tx.execute(state, block_context, true, true).unwrap_err();
     assert_matches!(
         error,
         TransactionExecutionError::ContractConstructorExecutionFailed(
@@ -1384,7 +1385,7 @@ fn test_fail_deploy_account_undeclared_class_hash(block_context: BlockContext) {
         .unwrap();
 
     let account_tx = AccountTransaction::DeployAccount(deploy_account);
-    let error = account_tx.execute(state, block_context, true, true, None).unwrap_err();
+    let error = account_tx.execute(state, block_context, true, true).unwrap_err();
     assert_matches!(
         error,
         TransactionExecutionError::ContractConstructorExecutionFailed(
@@ -1447,7 +1448,7 @@ fn test_validate_accounts_tx(
             ..default_args
         },
     );
-    let error = account_tx.execute(state, block_context, true, true, None).unwrap_err();
+    let error = account_tx.execute(state, block_context, true, true).unwrap_err();
     check_transaction_execution_error_for_invalid_scenario!(
         cairo_version,
         error,
@@ -1466,7 +1467,7 @@ fn test_validate_accounts_tx(
             ..default_args
         },
     );
-    let error = account_tx.execute(state, block_context, true, true, None).unwrap_err();
+    let error = account_tx.execute(state, block_context, true, true).unwrap_err();
     check_transaction_execution_error_for_custom_hint!(
         &error,
         "Unauthorized syscall call_contract in execution mode Validate.",
@@ -1484,7 +1485,7 @@ fn test_validate_accounts_tx(
                 ..default_args
             },
         );
-        let error = account_tx.execute(state, block_context, true, true, None).unwrap_err();
+        let error = account_tx.execute(state, block_context, true, true).unwrap_err();
         check_transaction_execution_error_for_custom_hint!(
             &error,
             "Unauthorized syscall get_block_hash in execution mode Validate.",
@@ -1501,7 +1502,7 @@ fn test_validate_accounts_tx(
                 ..default_args
             },
         );
-        let error = account_tx.execute(state, block_context, true, true, None).unwrap_err();
+        let error = account_tx.execute(state, block_context, true, true).unwrap_err();
         check_transaction_execution_error_for_custom_hint!(
             &error,
             "Unauthorized syscall get_sequencer_address in execution mode Validate.",
@@ -1524,7 +1525,7 @@ fn test_validate_accounts_tx(
             ..default_args
         },
     );
-    let result = account_tx.execute(state, block_context, true, true, None);
+    let result = account_tx.execute(state, block_context, true, true);
     assert!(result.is_ok(), "Execution failed: {:?}", result.unwrap_err());
 
     if tx_type != TransactionType::DeployAccount {
@@ -1540,7 +1541,7 @@ fn test_validate_accounts_tx(
                 ..default_args
             },
         );
-        let result = account_tx.execute(state, block_context, true, true, None);
+        let result = account_tx.execute(state, block_context, true, true);
         assert!(result.is_ok(), "Execution failed: {:?}", result.unwrap_err());
     }
 
@@ -1559,7 +1560,7 @@ fn test_validate_accounts_tx(
                 ..default_args
             },
         );
-        let result = account_tx.execute(state, block_context, true, true, None);
+        let result = account_tx.execute(state, block_context, true, true);
         assert!(result.is_ok(), "Execution failed: {:?}", result.unwrap_err());
 
         // Call the syscall get_block_timestamp and assert the returned timestamp was modified
@@ -1574,7 +1575,7 @@ fn test_validate_accounts_tx(
                 ..default_args
             },
         );
-        let result = account_tx.execute(state, block_context, true, true, None);
+        let result = account_tx.execute(state, block_context, true, true);
         assert!(result.is_ok(), "Execution failed: {:?}", result.unwrap_err());
     }
 
@@ -1595,7 +1596,7 @@ fn test_validate_accounts_tx(
                 ..default_args
             },
         );
-        let result = account_tx.execute(state, block_context, true, true, None);
+        let result = account_tx.execute(state, block_context, true, true);
         assert!(result.is_ok(), "Execution failed: {:?}", result.unwrap_err());
     }
 }
@@ -1621,8 +1622,7 @@ fn test_valid_flag(
         max_fee: Fee(MAX_FEE)
     });
 
-    let actual_execution_info =
-        account_tx.execute(state, block_context, true, false, None).unwrap();
+    let actual_execution_info = account_tx.execute(state, block_context, true, false).unwrap();
 
     assert!(actual_execution_info.validate_call_info.is_none());
 }
@@ -1697,7 +1697,7 @@ fn test_only_query_flag(block_context: BlockContext, #[values(true, false)] only
     );
     let account_tx = AccountTransaction::Invoke(invoke_tx);
 
-    let tx_execution_info = account_tx.execute(state, block_context, true, true, None).unwrap();
+    let tx_execution_info = account_tx.execute(state, block_context, true, true).unwrap();
     assert!(!tx_execution_info.is_reverted())
 }
 
@@ -1716,7 +1716,7 @@ fn test_l1_handler(#[values(false, true)] use_kzg_da: bool) {
     let value = calldata.0[2];
     let payload_size = tx.payload_size();
 
-    let actual_execution_info = tx.execute(state, block_context, true, true, None).unwrap();
+    let actual_execution_info = tx.execute(state, block_context, true, true).unwrap();
 
     // Build the expected call info.
     let accessed_storage_key = StorageKey::try_from(key).unwrap();
@@ -1830,7 +1830,7 @@ fn test_l1_handler(#[values(false, true)] use_kzg_da: bool) {
         )
         .unwrap();
     let tx_no_fee = L1HandlerTransaction::create_for_testing(Fee(0), contract_address);
-    let error = tx_no_fee.execute(state, block_context, true, true, None).unwrap_err();
+    let error = tx_no_fee.execute(state, block_context, true, true).unwrap_err();
     // Today, we check that the paid_fee is positive, no matter what was the actual fee.
     let expected_actual_fee =
         calculate_tx_fee(&expected_execution_info.actual_resources, block_context, &FeeType::Eth)
@@ -1863,13 +1863,11 @@ fn test_execute_tx_with_invalid_transaction_version(block_context: BlockContext)
         calldata,
     });
 
-    let execution_info = account_tx.execute(state, block_context, true, true, None).unwrap();
-    assert!(
-        execution_info
-            .revert_error
-            .unwrap()
-            .contains(format!("ASSERT_EQ instruction failed: {} != 1.", invalid_version).as_str())
-    );
+    let execution_info = account_tx.execute(state, block_context, true, true).unwrap();
+    assert!(execution_info
+        .revert_error
+        .unwrap()
+        .contains(format!("ASSERT_EQ instruction failed: {} != 1.", invalid_version).as_str()));
 }
 
 fn max_n_emitted_events() -> usize {
@@ -1932,17 +1930,17 @@ fn test_emit_event_exceeds_limit(
     );
 
     let calldata = [
-        vec![stark_felt!(
-            u16::try_from(n_emitted_events).expect("Failed to convert usize to u16.")
-        )]
+        vec![
+            stark_felt!(u16::try_from(n_emitted_events).expect("Failed to convert usize to u16.")),
+        ]
         .to_owned(),
-        vec![stark_felt!(
-            u16::try_from(event_keys.len()).expect("Failed to convert usize to u16.")
-        )],
+        vec![
+            stark_felt!(u16::try_from(event_keys.len()).expect("Failed to convert usize to u16.")),
+        ],
         event_keys.clone(),
-        vec![stark_felt!(
-            u16::try_from(event_data.len()).expect("Failed to convert usize to u16.")
-        )],
+        vec![
+            stark_felt!(u16::try_from(event_data.len()).expect("Failed to convert usize to u16.")),
+        ],
         event_data.clone(),
     ]
     .concat();
@@ -1966,7 +1964,7 @@ fn test_emit_event_exceeds_limit(
         version: TransactionVersion::ONE,
         nonce: nonce!(0_u8),
     });
-    let execution_info = account_tx.execute(state, block_context, true, true, None).unwrap();
+    let execution_info = account_tx.execute(state, block_context, true, true).unwrap();
     match &expected_error {
         Some(expected_error) => {
             let error_string = execution_info.revert_error.unwrap();

--- a/crates/native_blockifier/src/py_block_executor.rs
+++ b/crates/native_blockifier/src/py_block_executor.rs
@@ -198,7 +198,7 @@ impl PyBlockExecutor {
         let charge_fee = true;
         let tx_type: String = get_py_tx_type(tx).expect(PY_TX_PARSING_ERR).to_string();
         let tx: Transaction = py_tx(tx, optional_py_class_info).expect(PY_TX_PARSING_ERR);
-        let tx_execution_info = self.tx_executor().execute(&tx, charge_fee, None)?;
+        let tx_execution_info = self.tx_executor().execute(&tx, charge_fee)?;
         let typed_tx_execution_info = TypedTransactionExecutionInfo::from_tx_execution_info(
             &self.tx_executor().block_context,
             tx_execution_info,
@@ -236,7 +236,7 @@ impl PyBlockExecutor {
             .unzip();
 
         // Run.
-        let results = self.tx_executor().execute_txs(&txs, charge_fee, None);
+        let results = self.tx_executor().execute_txs(&txs, charge_fee);
 
         // Process results.
         // TODO(Yoni, 15/5/2024): serialize concurrently.

--- a/crates/native_blockifier/src/py_validator.rs
+++ b/crates/native_blockifier/src/py_validator.rs
@@ -67,7 +67,7 @@ impl PyValidator {
     ) -> NativeBlockifierResult<()> {
         let account_tx = py_account_tx(tx, optional_py_class_info).expect(PY_TX_PARSING_ERR);
         let deploy_account_tx_hash = deploy_account_tx_hash.map(|hash| TransactionHash(hash.0));
-        self.stateful_validator.perform_validations(account_tx, deploy_account_tx_hash, None)?;
+        self.stateful_validator.perform_validations(account_tx, deploy_account_tx_hash)?;
 
         Ok(())
     }

--- a/crates/native_blockifier/src/state_readers/papyrus_state_test.rs
+++ b/crates/native_blockifier/src/state_readers/papyrus_state_test.rs
@@ -59,7 +59,7 @@ fn test_entry_point_with_papyrus_state() -> papyrus_storage::StorageResult<()> {
     };
     let storage_address = entry_point_call.storage_address;
     assert_eq!(
-        entry_point_call.execute_directly(&mut state, None).unwrap().execution,
+        entry_point_call.execute_directly(&mut state).unwrap().execution,
         CallExecution::from_retdata(retdata![value])
     );
 

--- a/scripts/rust_fmt.sh
+++ b/scripts/rust_fmt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cargo +nightly fmt --all -- "$@"
+cargo +nightly-2024-01-12 fmt --all -- "$@"

--- a/scripts/rust_fmt.sh
+++ b/scripts/rust_fmt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cargo +nightly-2024-01-12 fmt --all -- "$@"
+cargo +nightly fmt --all -- "$@"


### PR DESCRIPTION
By storing the native executor with the contract class we can leverage the cache state reader to do the caching via `get_compiled_contract_class` instead of having to add another layer of caching. The main changes are in ` crates/blockifier/src/execution/contract_class.rs`, 