### PR TITLE
feat: add tracing feature

### DIFF
--- a/crates/blockifier/Cargo.toml
+++ b/crates/blockifier/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 [features]
 testing = ["rstest"]
 concurrency = []
+tracing = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -1313,3 +1313,28 @@ fn test_concurrency_execute_fee_transfer(#[values(FeeType::Eth, FeeType::Strk)] 
         assert_eq!(*seq_write_val.unwrap(), expexted_write_val);
     }
 }
+
+#[cfg(feature = "tracing")]
+#[rstest]
+fn test_tracing_duration(block_context: BlockContext, max_fee: Fee) {
+    let TestInitData { mut state, account_address, contract_address, mut nonce_manager } =
+        create_test_init_data(&block_context.chain_info, CairoVersion::Cairo0);
+
+    let tx_execution_info = run_invoke_tx(
+        &mut state,
+        &block_context,
+        invoke_tx_args! {
+            max_fee,
+            sender_address: account_address,
+            calldata: create_trivial_calldata(contract_address),
+            version: TransactionVersion::ONE,
+            nonce: nonce_manager.next(account_address),
+        },
+    )
+    .unwrap();
+
+    assert!(
+        tx_execution_info.duration.is_some(),
+        "Duration should be Some when tracing is enabled"
+    );
+}

--- a/crates/blockifier/src/transaction/objects.rs
+++ b/crates/blockifier/src/transaction/objects.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+#[cfg(feature = "tracing")]
 use std::time::Duration;
 
 use cairo_felt::Felt252;

--- a/crates/blockifier/src/transaction/objects.rs
+++ b/crates/blockifier/src/transaction/objects.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::time::Duration;
 
 use cairo_felt::Felt252;
 use cairo_vm::vm::runners::builtin_runner::SEGMENT_ARENA_BUILTIN_NAME;
@@ -235,6 +236,8 @@ pub struct TransactionExecutionInfo {
     // TODO(Dori, 1/8/2023): If the `Eq` and `PartialEq` traits are removed, or implemented on all
     //   internal structs in this enum, this field should be `Option<TransactionExecutionError>`.
     pub revert_error: Option<String>,
+    #[cfg(feature = "tracing")]
+    pub duration: Option<Duration>,
 }
 
 impl TransactionExecutionInfo {


### PR DESCRIPTION
## Description

Enables transaction durations to be trace-able, which is gated behind the `tracing` feature flag. 
This will be used to generate a time-series data for how long transactions take, as the cache increases in size, to illustrate the improvements in using cairo-native.

Currently the duration is stored with the transaction execution info, not sure if this is the best place to store it.

## Changes

- added `tracing` feature to `Cargo.toml`
- added some unit tests to check whether the trace works